### PR TITLE
Patch Title 12, Title 27 triple section characters

### DIFF
--- a/12/002-fix-triple-section-character/001.patch
+++ b/12/002-fix-triple-section-character/001.patch
@@ -1,0 +1,13 @@
+--- /Users/Andrew/Dropbox/code/ecfr-versioner/data/titles/preprocessed/xml/12/2017/01/2017-01-03.xml	2018-04-13 17:10:41.000000000 -0700
++++ tmp/title_version_13_preprocessed.xml	2018-04-13 17:11:09.000000000 -0700
+@@ -312565,8 +312565,8 @@
+ </DIV8>
+ 
+ 
+-<DIV8 N="§§§ 1207.4-1207.9" TYPE="SECTION">
+-<HEAD>§§§ 1207.4-1207.9   [Reserved]</HEAD>
++<DIV8 N="§§ 1207.4-1207.9" TYPE="SECTION">
++<HEAD>§§ 1207.4-1207.9   [Reserved]</HEAD>
+ </DIV8>
+ 
+ </DIV6>

--- a/12/002-fix-triple-section-character/meta.yml
+++ b/12/002-fix-triple-section-character/meta.yml
@@ -1,0 +1,8 @@
+description: Title 12 contains three section characters before a range that should only be two.
+tags: 'content-error'
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2015-01-01'
+    end_date: '2017-03-27'

--- a/27/001-fix-triple-section-character/001.patch
+++ b/27/001-fix-triple-section-character/001.patch
@@ -1,0 +1,13 @@
+--- /Users/Andrew/Dropbox/code/ecfr-versioner/data/titles/preprocessed/xml/27/2017/01/2017-01-03.xml	2018-04-13 17:33:09.000000000 -0700
++++ tmp/title_version_28_preprocessed.xml	2018-04-13 17:37:53.000000000 -0700
+@@ -37529,8 +37529,8 @@
+ </DIV8>
+ 
+ 
+-<DIV8 N="§§§ 21.45-21.46" TYPE="SECTION">
+-<HEAD>§§§ 21.45-21.46   [Reserved]</HEAD>
++<DIV8 N="§§ 21.45-21.46" TYPE="SECTION">
++<HEAD>§§ 21.45-21.46   [Reserved]</HEAD>
+ </DIV8>
+ 
+ 

--- a/27/001-fix-triple-section-character/meta.yml
+++ b/27/001-fix-triple-section-character/meta.yml
@@ -1,0 +1,8 @@
+description: Title 27 contains three section characters before a range that should only be two.
+tags: 'content-error'
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2015-01-01'
+    end_date: '2017-06-08'


### PR DESCRIPTION
This is a small patch to fix triple section characters that should be doubles. 

this closes #23 