### PR TITLE
Update Title 49 irregular part nodes to be text nodes #1

### DIFF
--- a/37/002-remove-blank-subchaps/001.patch
+++ b/37/002-remove-blank-subchaps/001.patch
@@ -1,0 +1,28 @@
+--- /Users/Andrew/Dropbox/code/ecfr-versioner/data/titles/preprocessed/xml/37/2018/04/2018-04-17.xml	2018-05-18 16:25:18.000000000 -0700
++++ tmp/title_version_63_preprocessed.xml	2018-05-18 16:33:33.000000000 -0700
+@@ -14532,12 +14532,8 @@
+ 
+ 
+ </PT></SUBCHIND>
+-</DIV4>
+ 
+ 
+-<DIV4 N="" TYPE="SUBCHAP">
+-<HEAD> 
+-</HEAD>
+ <TEXT>
+ <HED1>PART 1 - RULES OF PRACTICE IN PATENT CASES
+ </HED1>
+@@ -22579,12 +22575,8 @@
+ 
+ 
+ </PT></SUBCHIND>
+-</DIV4>
+ 
+ 
+-<DIV4 N="" TYPE="SUBCHAP">
+-<HEAD> 
+-</HEAD>
+ <TEXT>
+ <HED1><I>PRACTICE BEFORE THE PATENT AND TRADEMARK OFFICE</I>
+ 

--- a/37/002-remove-blank-subchaps/meta.yml
+++ b/37/002-remove-blank-subchaps/meta.yml
@@ -1,0 +1,8 @@
+description: Title 37 has two sets of blank subchapters that are used to wrap content in a weird order into unique Subchapter As. This removes these tags and wraps all of content in Parts 1-90 in a singe Subchapter A tag.
+tags: 'structural'
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2017-01-03'
+    end_date: '2100-01-01'

--- a/49/003-change-pseudo-Parts-to-Text/001.patch
+++ b/49/003-change-pseudo-Parts-to-Text/001.patch
@@ -1,0 +1,279 @@
+--- /Users/Andrew/Dropbox/code/ecfr-versioner/data/titles/preprocessed/xml/49/2017/01/2017-01-03.xml	2018-05-18 16:49:22.000000000 -0700
++++ tmp/title_version_84_preprocessed.xml	2018-05-21 12:19:25.000000000 -0700
+@@ -275525,12 +275525,11 @@
+ 
+ </HEAD>
+ 
+-<DIV5 N="1000-1019" TYPE="PART">
+-<HEAD>Parts 1000-1019 - General Provisions 
+-
+-
+-</HEAD>
+-</DIV5>
++<TEXT>
++  <HED1>
++    Parts 1000-1019 - General Provisions 
++  </HED1>
++</TEXT>
+ 
+ 
+ <DIV5 N="1000" TYPE="PART">
+@@ -278908,13 +278907,11 @@
+ 
+ </DIV5>
+ 
+-
+-<DIV5 N="1021-1029" TYPE="PART">
+-<HEAD>Parts 1021-1029 - Enforcement 
+-
+-
+-</HEAD>
+-</DIV5>
++<TEXT>
++  <HED1>
++    Parts 1021-1029 - Enforcement 
++  </HED1>
++</TEXT>
+ 
+ 
+ <DIV5 N="1021" TYPE="PART">
+@@ -279137,12 +279134,11 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="1030-1039" TYPE="PART">
+-<HEAD>Parts 1030-1039 - Carriers Subject to Part I, Interstate Commerce Act 
+-
+-
+-</HEAD>
+-</DIV5>
++<TEXT>
++  <HED1>
++    Parts 1030-1039 - Carriers Subject to Part I, Interstate Commerce Act 
++  </HED1>
++</TEXT>
+ 
+ 
+ <DIV5 N="1033" TYPE="PART">
+@@ -279928,13 +279924,11 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="1090-1099" TYPE="PART">
+-<HEAD>Parts 1090-1099 - Intermodal Transportation 
+-
+-
+-</HEAD>
+-</DIV5>
+-
++<TEXT>
++  <HED1>
++    Parts 1090-1099 - Intermodal Transportation 
++  </HED1>
++</TEXT>
+ 
+ <DIV5 N="1090" TYPE="PART">
+ <HEAD>PART 1090 - PRACTICES OF CARRIERS INVOLVED IN THE INTERMODAL MOVEMENT OF CONTAINERIZED FREIGHT
+@@ -280006,12 +280000,13 @@
+ 
+ </HEAD>
+ 
+-<DIV5 N="1100-1129" TYPE="PART">
+-<HEAD>Parts 1100-1129 - Rules of General Applicability
+ 
+ 
+-</HEAD>
+-</DIV5>
++<TEXT>
++  <HED1>
++    Parts 1100-1129 - Rules of General Applicability
++  </HED1>
++</TEXT>
+ 
+ 
+ <DIV5 N="1100" TYPE="PART">
+@@ -283621,13 +283616,11 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="1130-1149" TYPE="PART">
+-<HEAD>Parts 1130-1149 - Rate Procedures
+-
+-
+-</HEAD>
+-</DIV5>
+-
++<TEXT>
++  <HED1>
++    Parts 1130-1149 - Rate Procedures
++  </HED1>
++</TEXT>
+ 
+ <DIV5 N="1130" TYPE="PART">
+ <HEAD>PART 1130 - INFORMAL COMPLAINTS
+@@ -284116,21 +284109,18 @@
+ </HEAD>
+ </DIV5>
+ 
+-
+-<DIV5 N="1150-1176" TYPE="PART">
+-<HEAD>Parts 1150-1176 - Licensing Procedures
+-
+-
+-</HEAD>
+-</DIV5>
+-
+-
+-<DIV5 N="1150-1159" TYPE="PART">
+-<HEAD>Parts 1150-1159 - Rail Licensing Procedures
++<TEXT>
++  <HED1>
++    Parts 1150-1176 - Licensing Procedures
++  </HED1>
++</TEXT>
+ 
+ 
+-</HEAD>
+-</DIV5>
++<TEXT>
++  <HED1>
++    Parts 1150-1159 - Rail Licensing Procedures
++  </HED1>
++</TEXT>
+ 
+ 
+ <DIV5 N="1150" TYPE="PART">
+@@ -287938,21 +287928,22 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="1177-1199" TYPE="PART">
+-<HEAD>Parts 1177-1199 - Finance Procedures
+ 
++<TEXT>
++  <HED1>
++    Parts 1177-1199 - Finance Procedures
++  </HED1>
++</TEXT>
+ 
+-</HEAD>
+-</DIV5>
+ 
+ 
+-<DIV5 N="1177-1179" TYPE="PART">
+-<HEAD>Parts 1177-1179 - Securities, Security Interests and Financial Structures
++<TEXT>
++  <HED1>
++    Parts 1177-1179 - Securities, Security Interests and Financial Structures
++  </HED1>
++</TEXT>
+ 
+ 
+-</HEAD>
+-</DIV5>
+-
+ 
+ <DIV5 N="1177" TYPE="PART">
+ <HEAD>PART 1177 - RECORDATION OF DOCUMENTS
+@@ -288180,13 +288171,13 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="1180-1189" TYPE="PART">
+-<HEAD>Parts 1180-1189 - Combinations and Ownership
++<TEXT>
++  <HED1>
++    Parts 1180-1189 - Combinations and Ownership
++  </HED1>
++</TEXT>
+ 
+ 
+-</HEAD>
+-</DIV5>
+-
+ 
+ <DIV5 N="1180" TYPE="PART">
+ <HEAD>PART 1180 - RAILROAD ACQUISITION, CONTROL, MERGER, CONSOLIDATION PROJECT, TRACKAGE RIGHTS, AND LEASE PROCEDURES
+@@ -289461,13 +289452,12 @@
+ 
+ </HEAD>
+ 
+-<DIV5 N="1200-1219" TYPE="PART">
+-<HEAD>PARTS 1200-1219 - UNIFORM SYSTEMS OF ACCOUNTS
+-
+-
+-</HEAD>
+-</DIV5>
+ 
++<TEXT>
++  <HED1>
++    PARTS 1200-1219 - UNIFORM SYSTEMS OF ACCOUNTS
++  </HED1>
++</TEXT>
+ 
+ <DIV5 N="1200" TYPE="PART">
+ <HEAD>PART 1200 - GENERAL ACCOUNTING REGULATIONS UNDER THE INTERSTATE COMMERCE ACT
+@@ -298822,16 +298812,15 @@
+ 
+ </DIV5>
+ 
+-
+-<DIV5 N="1240" TYPE="PART">
+-<HEAD>PARTS 1240-1259 - REPORTS
+-
+-
+-</HEAD>
++<TEXT>
++  <HED1>
++    PARTS 1240-1259 - REPORTS
++  </HED1>
++</TEXT>
+ <NOTE>
+ <HED>Note:</HED>
+ <P>The report forms prescribed by parts 1240-1259 are available upon request from the Office of Economics, Surface Transportation Board, Washington, DC.</P></NOTE>
+-</DIV5>
++
+ 
+ 
+ <DIV5 N="1241" TYPE="PART">
+@@ -301982,14 +301971,15 @@
+ 
+ </DIV5>
+ 
++<TEXT>
++  <HED1>
++    PARTS 1260-1269 - VALUATION
++  </HED1>
++	<NOTE>
++	<HED>Note:</HED>
++	<P>The report forms prescribed by parts 1260-1269 are available upon request from the Office of Economics, Environmental Analysis, and Administration, Surface Transportation Board, Washington, DC 20423-0001.</P></NOTE>
++</TEXT>
+ 
+-<DIV5 N="1260" TYPE="PART">
+-<HEAD>PARTS 1260-1269 - VALUATION
+-</HEAD>
+-<NOTE>
+-<HED>Note:</HED>
+-<P>The report forms prescribed by parts 1260-1269 are available upon request from the Office of Economics, Environmental Analysis, and Administration, Surface Transportation Board, Washington, DC 20423-0001.</P></NOTE>
+-</DIV5>
+ 
+ 
+ <DIV5 N="1260-1261" TYPE="PART">
+@@ -302000,12 +301990,11 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="1280-1299" TYPE="PART">
+-<HEAD>PARTS 1280-1299 - CLASSIFICATION AND DECLASSIFICATION OF NATIONAL SECURITY INFORMATION AND MATERIAL
+-
+-
+-</HEAD>
+-</DIV5>
++<TEXT>
++  <HED1>
++    PARTS 1280-1299 - CLASSIFICATION AND DECLASSIFICATION OF NATIONAL SECURITY INFORMATION AND MATERIAL
++  </HED1>
++</TEXT>
+ 
+ 
+ <DIV5 N="1280" TYPE="PART">

--- a/49/003-change-pseudo-Parts-to-Text/002.patch
+++ b/49/003-change-pseudo-Parts-to-Text/002.patch
@@ -1,0 +1,254 @@
+--- /Users/Andrew/Dropbox/code/ecfr-versioner/data/titles/preprocessed/xml/49/2018/04/2018-04-23.xml	2018-05-21 15:39:44.000000000 -0700
++++ title_49_preprocedded_2018-04-23_already_patched.xml	2018-05-21 15:33:39.000000000 -0700
+@@ -285435,12 +285435,11 @@
+ 
+ </HEAD>
+ 
+-<DIV5 N="1000-1019" TYPE="PART">
+-<HEAD>Parts 1000-1019 - General Provisions 
+-
+-
+-</HEAD>
+-</DIV5>
++<TEXT>
++  <HED1>
++    Parts 1000-1019 - General Provisions 
++  </HED1>
++</TEXT>
+ 
+ 
+ <DIV5 N="1000" TYPE="PART">
+@@ -288833,13 +288832,11 @@
+ 
+ </DIV5>
+ 
+-
+-<DIV5 N="1021-1029" TYPE="PART">
+-<HEAD>Parts 1021-1029 - Enforcement 
+-
+-
+-</HEAD>
+-</DIV5>
++<TEXT>
++  <HED1>
++    Parts 1021-1029 - Enforcement 
++  </HED1>
++</TEXT>
+ 
+ 
+ <DIV5 N="1021" TYPE="PART">
+@@ -289048,12 +289045,11 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="1030-1039" TYPE="PART">
+-<HEAD>Parts 1030-1039 - Carriers Subject to Part I, Interstate Commerce Act 
+-
+-
+-</HEAD>
+-</DIV5>
++<TEXT>
++  <HED1>
++    Parts 1030-1039 - Carriers Subject to Part I, Interstate Commerce Act 
++  </HED1>
++</TEXT>
+ 
+ 
+ <DIV5 N="1033" TYPE="PART">
+@@ -289827,13 +289823,11 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="1090-1099" TYPE="PART">
+-<HEAD>Parts 1090-1099 - Intermodal Transportation 
+-
+-
+-</HEAD>
+-</DIV5>
+-
++<TEXT>
++  <HED1>
++    Parts 1090-1099 - Intermodal Transportation 
++  </HED1>
++</TEXT>
+ 
+ <DIV5 N="1090" TYPE="PART">
+ <HEAD>PART 1090 - PRACTICES OF CARRIERS INVOLVED IN THE INTERMODAL MOVEMENT OF CONTAINERIZED FREIGHT
+@@ -289904,12 +289898,13 @@
+ 
+ </HEAD>
+ 
+-<DIV5 N="1100-1129" TYPE="PART">
+-<HEAD>Parts 1100-1129 - Rules of General Applicability
+ 
+ 
+-</HEAD>
+-</DIV5>
++<TEXT>
++  <HED1>
++    Parts 1100-1129 - Rules of General Applicability
++  </HED1>
++</TEXT>
+ 
+ 
+ <DIV5 N="1100" TYPE="PART">
+@@ -293754,13 +293749,11 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="1130-1149" TYPE="PART">
+-<HEAD>Parts 1130-1149 - Rate Procedures
+-
+-
+-</HEAD>
+-</DIV5>
+-
++<TEXT>
++  <HED1>
++    Parts 1130-1149 - Rate Procedures
++  </HED1>
++</TEXT>
+ 
+ <DIV5 N="1130" TYPE="PART">
+ <HEAD>PART 1130 - INFORMAL COMPLAINTS
+@@ -294242,21 +294235,18 @@
+ </HEAD>
+ </DIV5>
+ 
+-
+-<DIV5 N="1150-1176" TYPE="PART">
+-<HEAD>Parts 1150-1176 - Licensing Procedures
+-
+-
+-</HEAD>
+-</DIV5>
+-
+-
+-<DIV5 N="1150-1159" TYPE="PART">
+-<HEAD>Parts 1150-1159 - Rail Licensing Procedures
++<TEXT>
++  <HED1>
++    Parts 1150-1176 - Licensing Procedures
++  </HED1>
++</TEXT>
+ 
+ 
+-</HEAD>
+-</DIV5>
++<TEXT>
++  <HED1>
++    Parts 1150-1159 - Rail Licensing Procedures
++  </HED1>
++</TEXT>
+ 
+ 
+ <DIV5 N="1150" TYPE="PART">
+@@ -298085,20 +298075,21 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="1177-1199" TYPE="PART">
+-<HEAD>Parts 1177-1199 - Finance Procedures
+-
+ 
+-</HEAD>
+-</DIV5>
++<TEXT>
++  <HED1>
++    Parts 1177-1199 - Finance Procedures
++  </HED1>
++</TEXT>
+ 
+ 
+-<DIV5 N="1177-1179" TYPE="PART">
+-<HEAD>Parts 1177-1179 - Securities, Security Interests and Financial Structures
+ 
++<TEXT>
++  <HED1>
++    Parts 1177-1179 - Securities, Security Interests and Financial Structures
++  </HED1>
++</TEXT>
+ 
+-</HEAD>
+-</DIV5>
+ 
+ 
+ <DIV5 N="1177" TYPE="PART">
+@@ -298330,12 +298321,12 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="1180-1189" TYPE="PART">
+-<HEAD>Parts 1180-1189 - Combinations and Ownership
+-
++<TEXT>
++  <HED1>
++    Parts 1180-1189 - Combinations and Ownership
++  </HED1>
++</TEXT>
+ 
+-</HEAD>
+-</DIV5>
+ 
+ 
+ <DIV5 N="1180" TYPE="PART">
+@@ -299620,13 +299611,12 @@
+ 
+ </HEAD>
+ 
+-<DIV5 N="1200-1219" TYPE="PART">
+-<HEAD>PARTS 1200-1219 - UNIFORM SYSTEMS OF ACCOUNTS
+-
+-
+-</HEAD>
+-</DIV5>
+ 
++<TEXT>
++  <HED1>
++    PARTS 1200-1219 - UNIFORM SYSTEMS OF ACCOUNTS
++  </HED1>
++</TEXT>
+ 
+ <DIV5 N="1200" TYPE="PART">
+ <HEAD>PART 1200 - GENERAL ACCOUNTING REGULATIONS UNDER THE INTERSTATE COMMERCE ACT
+@@ -308984,16 +308974,15 @@
+ 
+ </DIV5>
+ 
+-
+-<DIV5 N="1240" TYPE="PART">
+-<HEAD>PARTS 1240-1259 - REPORTS
+-
+-
+-</HEAD>
++<TEXT>
++  <HED1>
++    PARTS 1240-1259 - REPORTS
++  </HED1>
++</TEXT>
+ <NOTE>
+ <HED>Note:</HED>
+ <P>The report forms prescribed by parts 1240-1259 are available upon request from the Office of Economics, Surface Transportation Board, Washington, DC.</P></NOTE>
+-</DIV5>
++
+ 
+ 
+ <DIV5 N="1241" TYPE="PART">
+@@ -312378,12 +312367,11 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="1280-1299" TYPE="PART">
+-<HEAD>PARTS 1280-1299 - CLASSIFICATION AND DECLASSIFICATION OF NATIONAL SECURITY INFORMATION AND MATERIAL
+-
+-
+-</HEAD>
+-</DIV5>
++<TEXT>
++  <HED1>
++    PARTS 1280-1299 - CLASSIFICATION AND DECLASSIFICATION OF NATIONAL SECURITY INFORMATION AND MATERIAL
++  </HED1>
++</TEXT>
+ 
+ 
+ <DIV5 N="1280" TYPE="PART">

--- a/49/003-change-pseudo-Parts-to-Text/meta.yml
+++ b/49/003-change-pseudo-Parts-to-Text/meta.yml
@@ -1,0 +1,11 @@
+description: Title 49 has a number of Part nodes that are actually more like subject groups or labels. This patch changes these nodes to be TEXT and HED1 nodes instead of DIV5s.
+tags: ['structural']
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2017-01-03'
+    end_date: '2018-04-20'
+  '002':
+    start_date: '2018-04-21'
+    end_date: '2100-01-01'


### PR DESCRIPTION
This updates a number of overlapping label or grouping parts to be `<Text/>` nodes to more accurately match their purpose and allow us to better process the xml. 

this closes #1 