### PR TITLE
Remove empty part node from Title 24 - Subtitle A

### DIFF
--- a/24/001-remove-empty-part/001.patch
+++ b/24/001-remove-empty-part/001.patch
@@ -1,0 +1,22 @@
+--- /Users/Andrew/Dropbox/code/ecfr-versioner/data/titles/preprocessed/xml/24/2017/01/2017-01-03.xml	2018-08-22 09:49:49.000000000 -0700
++++ tmp/title_version_1_preprocessed.xml	2018-08-22 09:50:17.000000000 -0700
+@@ -27469,11 +27469,8 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="" TYPE="PART">
+-<HEAD> 
+ 
+ 
+-</HEAD>
+ 
+ <DIV9 N="" TYPE="APPENDIX">
+ <HEAD>Appendixes A-C to Subtitle A [Reserved]
+@@ -27482,7 +27479,6 @@
+ </HEAD>
+ </DIV9>
+ 
+-</DIV5>
+ 
+ </DIV2>
+ 

--- a/24/001-remove-empty-part/meta.yml
+++ b/24/001-remove-empty-part/meta.yml
@@ -1,0 +1,8 @@
+description: Title 24 contains an appendix that is beneath an empty part. We're removing the empty part and setting the appendix to be a descendant of a Subtitle A.
+tags: 'content-error'
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2015-01-01'
+    end_date: '2100-01-01'


### PR DESCRIPTION
This patches Title 24 `Appendixes A-C to Subtitle A [Reserved]` to be a direct descendant of a subtitle instead of an empty part.

This closes #40 