### PR TITLE
Title 14 Malformed amendment date ends #45

### DIFF
--- a/14/002-fix-missing-malformed-amendment-date/meta.yml
+++ b/14/002-fix-missing-malformed-amendment-date/meta.yml
@@ -5,4 +5,4 @@ status: 'needs-approval'
 patches:
   '001':
     start_date: '2017-07-27'
-    end_date: '2017-08-22'
+    end_date: '2017-08-05'


### PR DESCRIPTION
This malformed date is replaced in the next title xml and is no longer needed after 2017-08-06.

This closes #45 