### PR TITLE
Update incorrect chapter node to be subtitle node #47

### DIFF
--- a/45/001-fix-incorrect-node-type/001.patch
+++ b/45/001-fix-incorrect-node-type/001.patch
@@ -1,0 +1,11 @@
+--- tmp/title_version_39_preprocessed.xml	2018-12-31 14:16:24.000000000 -0800
++++ /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/45/2017/01/2017-01-03.xml	2018-12-31 14:31:08.000000000 -0800
+@@ -51,7 +51,7 @@
+ 
+ </PG></CHAPTI></CFRTOC>
+ 
+-<DIV3 N="A" TYPE="CHAPTER">
++<DIV2 N="A" TYPE="SUBTITLE">
+ 
+ <HEAD> Subtitle A - Department of Health and Human Services</HEAD>
+ 

--- a/45/001-fix-incorrect-node-type/meta.yml
+++ b/45/001-fix-incorrect-node-type/meta.yml
@@ -1,0 +1,8 @@
+description: "The first subtitle in Title 45 is incorrectly structured as a chapter node instead of a subtitle node. In print and in the head tag this displays as a subtitle."
+tags: 'structural'
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2015-01-01'
+    end_date: '2099-01-01'


### PR DESCRIPTION
This fixes an issue where an incorrect node type was being used which resulted in incorrect links and content issues. 

This closes #47 

