### PR TITLE
Remove 29 CFR 2201.8 dup, stubbed section tag

### DIFF
--- a/29/003-remove-dup-stub-section/001.patch
+++ b/29/003-remove-dup-stub-section/001.patch
@@ -1,0 +1,14 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/29/2017/01/2017-01-03.xml	2019-02-04 16:27:36.000000000 -0800
++++ tmp/title_version_5_preprocessed.xml	2019-02-04 16:42:27.000000000 -0800
+@@ -235534,11 +235534,6 @@
+ 
+ <DIV8 N="§ 2201.8" TYPE="SECTION">
+ <HEAD>§ 2201.8   Fees for copying, searching, and review.</HEAD>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 2201.8" TYPE="SECTION">
+-<HEAD>§ 2201.8   Fees for copying, searching, and review.</HEAD>
+ <P>(a) <I>Fees required unless waived.</I> The FOIA Disclosure Officer shall charge fees in accordance with the Uniform Freedom of Information Fee Schedule and Guidelines published by the Office of Management and Budget and in accordance with paragraph (b) of this section. See Appendix A to this part. If the fees for a request are less than the threshold amount as provided in OSHRC's fee schedule, no fees shall be charged. The FOIA Disclosure Officer shall, however, waive the fees in the circumstances stated in § 2201.9.
+ 
+ 

--- a/29/003-remove-dup-stub-section/meta.yml
+++ b/29/003-remove-dup-stub-section/meta.yml
@@ -1,0 +1,8 @@
+description: This removes a duplicate, stubbed Section 2201.8
+tags: 'content-error'
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2015-01-01'
+    end_date: '2017-06-20'


### PR DESCRIPTION
This creates a patch to remove duplicate stubbed section 2201.8 from 2017-01-03 to 2017-06-20.

This closes #57 