### PR TITLE
Remove duplicate 49 CFR 360.3T section #63

### DIFF
--- a/49/004-remove-duplicate-360.3t/001.patch
+++ b/49/004-remove-duplicate-360.3t/001.patch
@@ -1,0 +1,96 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/49/2017/01/2017-01-24.xml	2019-02-12 15:44:44.000000000 -0800
++++ tmp/title_version_4_preprocessed.xml	2019-02-12 15:46:05.000000000 -0800
+@@ -174875,93 +174875,6 @@
+ <HED>Effective Date Note:</HED><PSPACE>At 82 FR 5297, Jan. 17, 2017, § 360.5 was suspended, effective Jan. 14, 2017.</PSPACE></EFFDNOT>
+ </DIV8>
+ 
+-
+-<DIV8 N="§ 360.3T" TYPE="SECTION">
+-<HEAD>§ 360.3T   Filing fees.</HEAD>
+-<P>(a) <I>Manner of payment.</I> (1) Except for the insurance fees described in the next sentence, all filing fees will be payable at the time and place the application, petition, or other document is tendered for filing. The service fee for insurance, surety or self-insurer accepted certificate of insurance, surety bond or other instrument submitted in lieu of a broker surety bond must be charged to an insurance service account established by the Federal Motor Carrier Safety Administration in accordance with paragraph (a)(2) of this section.
+-</P>
+-<P>(2) <I>Billing account procedure.</I> A written request must be submitted to the Office of Enforcement and Compliance, Insurance Compliance Division (MC-ECI) to establish an insurance service fee account.
+-</P>
+-<P>(i) Each account will have a specific billing date within each month and a billing cycle. The billing date is the date that the bill is prepared and printed. The billing cycle is the period between the billing date in one month and the billing date in the next month. A bill for each account which has activity or an unpaid balance during the billing cycle will be sent on the billing date each month. Payment will be due 20 days from the billing date. Payments received before the next billing date are applied to the account. Interest will accrue in accordance with 4 CFR 102.13.
+-</P>
+-<P>(ii) The Debt Collection Act of 1982, including disclosure to the consumer reporting agencies and the use of collection agencies, as set forth in 4 CFR 102.5 and 102.6 will be utilized to encourage payment where appropriate.
+-</P>
+-<P>(iii) An account holder who files a petition in bankruptcy or who is the subject of a bankruptcy proceeding must provide the following information to the Office of Enforcement and Compliance, Insurance Division (MC-ECI):
+-</P>
+-<P>(A) The filing date of the bankruptcy petition;
+-</P>
+-<P>(B) The court in which the bankruptcy petition was filed;
+-</P>
+-<P>(C) The type of bankruptcy proceeding;
+-</P>
+-<P>(D) The name, address, and telephone number of its representative in the bankruptcy proceeding; and
+-</P>
+-<P>(E) The name, address, and telephone number of the bankruptcy trustee, if one has been appointed.
+-</P>
+-<P>(3) Fees will be payable to the Federal Motor Carrier Safety Administration by a check payable in United States currency drawn upon funds deposited in a United States or foreign bank or other financial institution, money order payable in United States' currency, or credit card (VISA or MASTERCARD).
+-</P>
+-<P>(b) Any filing that is not accompanied by the appropriate filing fee is deficient except for filings that satisfy the deferred payment procedures in paragraph (a) of this section.
+-</P>
+-<P>(c) <I>Fees not refundable.</I> Fees will be assessed for every filing in the type of proceeding listed in the schedule of fees contained in paragraph (f) of this section, subject to the exceptions contained in paragraphs (d) and (e) of this section. After the application, petition, or other document has been accepted for filing by the Federal Motor Carrier Safety Administration, the filing fee will not be refunded, regardless of whether the application, petition, or other document is granted or approved, denied, rejected before docketing, dismissed, or withdrawn.
+-</P>
+-<P>(d) <I>Related or consolidated proceedings.</I> (1) Separate fees need not be paid for related applications filed by the same applicant which would be the subject of one proceeding. (This does not mean requests for multiple types of operating authority filed on forms in the OP-1 series under the regulations at 49 CFR part 365. A separate filing fee is required for each type of authority sought in each transportation mode, <I>e.g.,</I> common, contract, and broker authority for motor property carriers.)
+-</P>
+-<P>(2) Separate fees will be assessed for the filing of temporary operating authority applications as provided in paragraph (f)(6) of this section, regardless of whether such applications are related to an application for corresponding permanent operating authority.
+-</P>
+-<P>(3) The Federal Motor Carrier Safety Administration may reject concurrently filed applications, petitions, or other documents asserted to be related and refund the filing fee if, in its judgment, they embrace two or more severable matters which should be the subject of separate proceedings.
+-</P>
+-<P>(e) <I>Waiver or reduction of filing fees.</I> It is the general policy of the Federal Motor Carrier Safety Administration not to waive or reduce filing fees except as described as follows:
+-</P>
+-<P>(1) Filing fees are waived for an application or other proceeding which is filed by a Federal government agency, or a State or local government entity. For purposes of this section the phrases “Federal government agency” or “government entity” do not include a quasi-governmental corporation or government subsidized transportation company.
+-</P>
+-<P>(2) In extraordinary situations the Federal Motor Carrier Safety Administration will accept requests for waivers or fee reductions in accordance with the following procedure:
+-</P>
+-<P>(i) <I>When to request.</I> At the time that a filing is submitted to the Federal Motor Carrier Safety Administration the applicant may request a waiver or reduction of the fee prescribed in this part. Such request should be addressed to the Director, Office of Data Analysis and Information Systems.
+-</P>
+-<P>(ii) <I>Basis.</I> The applicant must show the waiver or reduction of the fee is in the best interest of the public, or that payment of the fee would impose an undue hardship upon the requestor.
+-</P>
+-<P>(iii) <I>Federal Motor Carrier Safety Administration action.</I> The Director, Office of Data Analysis and Information Systems, will notify the applicant of the decision to grant or deny the request for waiver or reduction.
+-</P>
+-<P>(f) <I>Schedule of filing fees.</I>
+-</P>
+-<DIV width="100%"><DIV class="gpotbl_div"><TABLE border="1" cellpadding="1" cellspacing="1" class="gpotbl_table" frame="void" width="100%"><TR><TH class="gpotbl_colhed" scope="col">Type of proceeding
+-</TH><TH class="gpotbl_colhed" scope="col"> 
+-</TH><TH class="gpotbl_colhed" scope="col">Fee
+-</TH></TR><TR><TD align="left" class="gpotbl_cell" scope="row">Part I: Licensing:
+-</TD><TD align="left" class="gpotbl_cell"/><TD align="left" class="gpotbl_cell"/></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(1)</TD><TD align="left" class="gpotbl_cell">An application for motor carrier operating authority, a certificate of registration for certain foreign carriers, property broker authority, or freight forwarder authority</TD><TD align="left" class="gpotbl_cell">$300.
+-</TD></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(2)</TD><TD align="left" class="gpotbl_cell">A petition to interpret or clarify an operating authority</TD><TD align="left" class="gpotbl_cell">3,000.
+-</TD></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(3)</TD><TD align="left" class="gpotbl_cell">A request seeking the modification of operating authority only to the extent of making a ministerial correction, when the original error was caused by applicant, a change in the name of the shipper or owner of a plant site, or the change of a highway name or number</TD><TD align="left" class="gpotbl_cell">50.
+-</TD></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(4)</TD><TD align="left" class="gpotbl_cell">A petition to renew authority to transport explosives</TD><TD align="left" class="gpotbl_cell">250.
+-</TD></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(5)</TD><TD align="left" class="gpotbl_cell">An application for authority to deviate from authorized regular-route authority</TD><TD align="left" class="gpotbl_cell">150.
+-</TD></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(6)</TD><TD align="left" class="gpotbl_cell">An application for motor carrier temporary authority issued in an emergency situation</TD><TD align="left" class="gpotbl_cell">100.
+-</TD></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(7)</TD><TD align="left" class="gpotbl_cell">Request for name change of a motor carrier, property broker, or freight forwarder</TD><TD align="left" class="gpotbl_cell">14.
+-</TD></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(8)</TD><TD align="left" class="gpotbl_cell">An application involving the merger, transfer, or lease of the operating rights of motor passenger and property carriers, property brokers, and household goods freight forwarders under 49 U.S.C. 10321 and 10926</TD><TD align="left" class="gpotbl_cell">300.
+-</TD></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(9)-(49)</TD><TD align="left" class="gpotbl_cell">[Reserved]
+-</TD><TD align="left" class="gpotbl_cell"/></TR><TR><TD align="left" class="gpotbl_cell" scope="row">Part II: Insurance:
+-</TD><TD align="left" class="gpotbl_cell"/><TD align="left" class="gpotbl_cell"/></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(50)</TD><TD align="left" class="gpotbl_cell">(i) An application for original qualification as self-insurer for bodily injury and property damage insurance (BI&amp;PD)</TD><TD align="left" class="gpotbl_cell">4,200.
+-</TD></TR><TR><TD align="left" class="gpotbl_cell" scope="row"> </TD><TD align="left" class="gpotbl_cell">(ii) An application for original qualification as self-insurer for cargo insurance</TD><TD align="left" class="gpotbl_cell">420.
+-</TD></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(51)</TD><TD align="left" class="gpotbl_cell">A service fee for insurer, surety, or self-insurer accepted certificate of insurance, surety bond, and other instrument submitted in lieu of a broker surety bond</TD><TD align="left" class="gpotbl_cell">$10 per accepted certificate, surety bond or other instrument submitted in lieu of a broker surety bond.
+-</TD></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(52)</TD><TD align="left" class="gpotbl_cell">A petition for reinstatement of revoked operating authority</TD><TD align="left" class="gpotbl_cell">80.
+-</TD></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(53)-(79)</TD><TD align="left" class="gpotbl_cell">[Reserved]
+-</TD><TD align="left" class="gpotbl_cell"/></TR><TR><TD align="left" class="gpotbl_cell" scope="row">Part III: Services:
+-</TD><TD align="left" class="gpotbl_cell"/><TD align="left" class="gpotbl_cell"/></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(80)</TD><TD align="left" class="gpotbl_cell">Request for service or pleading list for proceedings</TD><TD align="left" class="gpotbl_cell">13 per list.
+-</TD></TR><TR><TD align="left" class="gpotbl_cell" scope="row" style="padding-left: 4em">(81)</TD><TD align="left" class="gpotbl_cell">Faxed copies of operating authority to applicants or their representatives who did not receive a served copy</TD><TD align="left" class="gpotbl_cell">5.</TD></TR></TABLE></DIV></DIV>
+-<P>(g) <I>Returned check policy.</I> (1) If a check submitted to the FMCSA for a filing or service fee is dishonored by a bank or financial institution on which it is drawn, the FMCSA will notify the person who submitted the check that:
+-</P>
+-<P>(i) All work will be suspended on the filing or proceeding, until the check is made good;
+-</P>
+-<P>(ii) A returned check charge of $6.00 and any bank charges incurred by the FMCSA as a result of the dishonored check must be submitted with the filing fee which is outstanding; and
+-</P>
+-<P>(iii) If payment is not made within the time specified by the FMCSA, the proceeding will be dismissed or the filing may be rejected.
+-</P>
+-<P>(2) If a person repeatedly submits dishonored checks to the FMCSA for filing fees, the FMCSA may notify the person that all future filing fees must be submitted in the form of a certified or cashier's check, money order, or credit card.
+-</P>
+-<CITA TYPE="N">[82 FR 5298, Jan. 17, 2017]
+-
+-
+-</CITA>
+-</DIV8>
+-
+ </DIV5>
+ 
+ 

--- a/49/004-remove-duplicate-360.3t/meta.yml
+++ b/49/004-remove-duplicate-360.3t/meta.yml
@@ -1,0 +1,8 @@
+description: Title 49 has a duplicate Section 360.3T that is located after 360.5 instead of after 360.3. This removes this section.
+tags: ['structural, transcription-error']
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2017-01-24'
+    end_date: '2017-03-15'


### PR DESCRIPTION
This creates a patch to remove a duplicate section 360.3T which shows up in `2017-01-24, 2017-01-27, 2017-02-13, 2017-02-15, 2017-03-15`. This closes #63 