### PR TITLE
Remove duplicate 27 CFR 24.245 #62

### DIFF
--- a/27/002-remove-duplicate-24.245/001.patch
+++ b/27/002-remove-duplicate-24.245/001.patch
@@ -1,0 +1,22 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/27/2017/01/2017-01-27.xml	2019-02-12 16:54:48.000000000 -0800
++++ tmp/title_version_7_preprocessed.xml	2019-02-12 16:56:36.000000000 -0800
+@@ -44769,19 +44769,6 @@
+ </DIV8>
+ 
+ 
+-<DIV8 N="§ 24.245" TYPE="SECTION">
+-<HEAD>§ 24.245   Use of carbon dioxide in still wine.</HEAD>
+-<P>The addition of carbon dioxide to (and retention in) still wine is permitted if at the time of removal for consumption or sale the still wine does not contain more than 0.392 grams of carbon dioxide per 100 milliliters of wine. However, a tolerance of not more than 0.009 grams per 100 milliliters to the maximum limitation of carbon dioxide in still wine will be allowed where the amount of carbon dioxide in excess of 0.392 grams per 100 milliliters is due to mechanical variations which can not be completely controlled under good commercial practice. A tolerance will not be allowed where it is found that the proprietor continuously or intentionally exceeds 0.392 grams of carbon dioxide per 100 milliliters of wine or where the variation results from the use of methods or equipment determined by the appropriate TTB officer not in accordance with good commercial practice. The proprietor shall determine the amount of carbon dioxide added to wine using authorized test procedures. Penalties are provided in 26 U.S.C. 5662 for any person who, whether by manner of packaging or advertising or by any other form of representation, misrepresents any still wine to be effervescent wine or a substitute for effervescent wine. 
+-</P>
+-<SECAUTH TYPE="N">(Sec. 201, Pub. L. 85-859, 72 Stat. 1331, as amended, 1381, as amended, 1407, as amended (26 U.S.C. 5041, 5367, 5662))
+-</SECAUTH>
+-<CITA TYPE="N">[T.D. ATF-299, 55 FR 24989, June 19, 1990, as amended by T.D. ATF-409, 64 FR 13683, Mar. 22, 1999]
+-
+-
+-</CITA>
+-</DIV8>
+-
+-
+ <DIV8 N="§ 24.246" TYPE="SECTION">
+ <HEAD>§ 24.246   Materials authorized for the treatment of wine and juice.</HEAD>
+ <P>(a) <I>Wine.</I> Materials used in the process of filtering, clarifying, or purifying wine may remove cloudiness, precipitation, and undesirable odors and flavors, but the addition of any substance foreign to wine which changes the character of the wine, or the abstraction of ingredients which will change its character, to the extent inconsistent with good commercial practice, is not permitted on bonded wine premises. The materials listed in this section are approved, as being consistent with good commercial practice in the production, cellar treatment, or finishing of wine, and where applicable in the treatment of juice, within the general limitations of this section: <I>Provided,</I> That:

--- a/27/002-remove-duplicate-24.245/meta.yml
+++ b/27/002-remove-duplicate-24.245/meta.yml
@@ -1,0 +1,8 @@
+description: Title 27 contains two Section 24.245. This removes the second one that should be replaced by the other.
+tags: ['structural, transcription-error']
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2017-01-27'
+    end_date: '2017-02-14'


### PR DESCRIPTION
This removes a second 27 CFR 24.245 section. This section is older and should be replaced by the newer version. 

This closes #62 