### PR TITLE
Removes second 7 CFR 1221.128 section that is a dup/subset of other section

### DIFF
--- a/07/002-remove-dup-section-1221.128/001.patch
+++ b/07/002-remove-dup-section-1221.128/001.patch
@@ -1,0 +1,22 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/07/2018/10/2018-10-25.xml	2019-02-14 15:31:36.000000000 -0800
++++ tmp/title_version_24_preprocessed.xml	2019-02-14 15:33:41.000000000 -0800
+@@ -307263,19 +307263,6 @@
+ </DIV8>
+ 
+ 
+-<DIV8 N="§ 1221.128" TYPE="SECTION">
+-<HEAD>§ 1221.128   Qualification.</HEAD>
+-<P>(a) Organizations receiving qualification from the Secretary will be entitled to submit requests for funding to the Board pursuant to § 1221.112(h). Only one sorghum producer organization per State may be qualified.
+-</P>
+-<CITA TYPE="N">[83 FR 35106, July 25, 2018]
+-
+-
+-
+-
+-
+-
+-</CITA>
+-</DIV8>
+ 
+ </DIV7>
+ 

--- a/07/002-remove-dup-section-1221.128/meta.yml
+++ b/07/002-remove-dup-section-1221.128/meta.yml
@@ -1,0 +1,8 @@
+description: "7 CFR 1221.128 contains a duplicate section tag. The duplicate tag content is a subset of the original section so this removes the second tag."
+tags: 'content-error'
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2018-10-25'
+    end_date: '2100-01-01'


### PR DESCRIPTION
This patches a duplicate section where the content is a subset of the the sibling duplicate section. This removes the second section.

This closes #70 