### PR TITLE
Fix Malformed year #73

### DIFF
--- a/50/005-fix-amendment-dates/001.patch
+++ b/50/005-fix-amendment-dates/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/50/2019/02/2019-02-12.xml	2019-02-15 16:27:56.000000000 -0800
++++ tmp/title_version_27_preprocessed.xml	2019-02-15 16:29:16.000000000 -0800
+@@ -172009,7 +172009,7 @@
+ 
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>Jan. 4, 20199
++<AMDDATE>Jan. 4, 2019
+ </AMDDATE>
+ 
+ <DIV1 N="12" TYPE="TITLE">

--- a/50/005-fix-amendment-dates/002.patch
+++ b/50/005-fix-amendment-dates/002.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/50/2019/02/2019-02-14.xml	2019-02-15 16:36:55.000000000 -0800
++++ tmp/title_version_29_preprocessed.xml	2019-02-15 16:37:29.000000000 -0800
+@@ -172009,7 +172009,7 @@
+ 
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>Jan. 14, 20199
++<AMDDATE>Jan. 14, 2019
+ </AMDDATE>
+ 
+ <DIV1 N="12" TYPE="TITLE">

--- a/50/005-fix-amendment-dates/meta.yml
+++ b/50/005-fix-amendment-dates/meta.yml
@@ -1,0 +1,11 @@
+description: Year is '20199' instead of '2019'. Remove extra '9'.
+tags: ['structural']
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2019-02-12'
+    end_date: '2019-02-12'
+  '002':
+    start_date: '2019-02-14'
+    end_date: '2100-01-01'


### PR DESCRIPTION
This fixes a two instances where the year is incorrect, '20199' instead of '2019'

This closes #73 