### PR TITLE
Patch and remove 16 CFR 23 duplicate-older sections #76

### DIFF
--- a/16/001-remove-old-dup-sections-part-23/001.patch
+++ b/16/001-remove-old-dup-sections-part-23/001.patch
@@ -1,0 +1,572 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/16/2018/08/2018-08-18.xml	2019-02-19 10:21:00.000000000 -0800
++++ tmp/title_version_16_2018-08-18_preprocessed.xml	2019-02-19 10:28:50.000000000 -0800
+@@ -6573,569 +6573,6 @@
+ </DIV9>
+ 
+ 
+-<DIV8 N="§ 23.0" TYPE="SECTION">
+-<HEAD>§ 23.0   Scope and application.</HEAD>
+-<P>(a) These guides apply to jewelry industry products, which include, but are not limited to, the following: gemstones and their laboratory-created and imitation substitutes; natural and cultured pearls and their imitations; and metallic watch bands not permanently attached to watches. These guides also apply to articles, including optical frames, pens and pencils, flatware, and hollowware, fabricated from precious metals (gold, silver and platinum group metals), precious metal alloys, and their imitations. These guides also apply to all articles made from pewter. For the purposes of these guides, all articles covered by these guides are defined as “industry products.”
+-</P>
+-<P>(b) These guides apply to persons, partnerships, or corporations, at every level of the trade (including but not limited to manufacturers, suppliers, and retailers) engaged in the business of offering for sale, selling, or distributing industry products.
+-</P>
+-<NOTE>
+-<HED>Note to paragraph (<E T="01">b</E>):</HED>
+-<P>To prevent consumer deception, persons, partnerships, or corporations in the business of appraising, identifying, or grading industry products should utilize the terminology and standards set forth in the guides.</P></NOTE>
+-<P>(c) These guides apply to claims and representations about industry products included in labeling, advertising, promotional materials, and all other forms of marketing, whether asserted directly or by implication, through words, symbols, emblems, logos, illustrations, depictions, product brand names, or through any other means.
+-</P>
+-<P>(d) These guides set forth the Federal Trade Commission's current thinking about claims for jewelry and other articles made from precious metals and pewter. The guides help marketers and other industry members avoid making claims that are unfair or deceptive under Section 5 of the FTC Act, 15 U.S.C. 45. They do not confer any rights on any person and do not operate to bind the FTC or the public. The Commission, however, may take action under the FTC Act if a marketer or other industry member makes a claim inconsistent with the guides. In any such enforcement action, the Commission must prove that the challenged act or practice is unfair or deceptive in violation of Section 5 of the FTC Act.
+-</P>
+-<P>(e) The guides consist of general principles, specific guidance on the use of particular claims for industry products, and examples. Claims may raise issues that are addressed by more than one example and in more than one section of the guides. The examples provide the Commission's views on how reasonable consumers likely interpret certain claims. Industry members may use an alternative approach if the approach satisfies the requirements of Section 5 of the FTC Act. Whether a particular claim is deceptive will depend on the net impression of the advertisement, label, or other promotional material at issue. In addition, although many examples present specific claims and options for qualifying claims, the examples do not illustrate all permissible claims or qualifications under Section 5 of the FTC Act.
+-</P>
+-<CITA TYPE="N">[61 FR 27212, May 30, 1996, as amended at 64 FR 33194, June 22, 1999; 75 FR 81453, Dec. 28, 2010]
+-
+-
+-</CITA>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.1" TYPE="SECTION">
+-<HEAD>§ 23.1   Deception (general).</HEAD>
+-<P>It is unfair or deceptive to misrepresent the type, kind, grade, quality, quantity, metallic content, size, weight, cut, color, character, treatment, substance, durability, serviceability, origin, price, value, preparation, production, manufacture, distribution, or any other material aspect of an industry product.
+-</P>
+-<NOTE>
+-<HED>Note 1 to § 23.1:</HED>
+-<P>If, in the sale or offering for sale of an industry product, any representation is made as to the grade assigned the product, the identity of the grading system used should be disclosed.</P></NOTE>
+-<NOTE>
+-<HED>Note 2 to § 23.1:</HED>
+-<P>To prevent deception, any qualifications or disclosures, such as those described in the guides, should be sufficiently clear and prominent. Clarity of language, relative type size and proximity to the claim being qualified, and an absence of contrary claims that could undercut effectiveness, will maximize the likelihood that the qualifications and disclosures are appropriately clear and prominent.</P></NOTE>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.2" TYPE="SECTION">
+-<HEAD>§ 23.2   Misleading illustrations.</HEAD>
+-<P>It is unfair or deceptive to use, as part of any advertisement, packaging material, label, or other sales promotion matter, any visual representation, picture, televised or computer image, illustration, diagram, or other depiction which, either alone or in conjunction with any accompanying words or phrases, misrepresents the type, kind, grade, quality, quantity, metallic content, size, weight, cut, color, character, treatment, substance, durability, serviceability, origin, preparation, production, manufacture, distribution, or any other material aspect of an industry product.
+-</P>
+-<NOTE>
+-<HED>Note to § 23.2:</HED>
+-<P>An illustration or depiction of a diamond or other gemstone that portrays it in greater than its actual size may mislead consumers, unless a disclosure is made about the item's true size.</P></NOTE>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.3" TYPE="SECTION">
+-<HEAD>§ 23.3   Misuse of the terms “hand-made,” “hand-polished,” etc.</HEAD>
+-<P>(a) It is unfair or deceptive to represent, directly or by implication, that any industry product is hand-made or hand-wrought unless the entire shaping and forming of such product from raw materials and its finishing and decoration were accomplished by hand labor and manually-controlled methods which permit the maker to control and vary the construction, shape, design, and finish of each part of each individual product.
+-</P>
+-<NOTE>
+-<HED>Note to paragraph (<E T="01">a</E>):</HED>
+-<P>As used herein, “raw materials” include bulk sheet, strip, wire, and similar items that have not been cut, shaped, or formed into jewelry parts, semi-finished parts, or blanks.</P></NOTE>
+-<P>(b) It is unfair or deceptive to represent, directly or by implication, that any industry product is hand-forged, hand-engraved, hand-finished, or hand-polished, or has been otherwise hand-processed, unless the operation described was accomplished by hand labor and manually-controlled methods which permit the maker to control and vary the type, amount, and effect of such operation on each part of each individual product.
+-
+-
+-</P>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.4" TYPE="SECTION">
+-<HEAD>§ 23.4   Misrepresentation as to gold content.</HEAD>
+-<P>(a) It is unfair or deceptive to misrepresent the presence of gold or gold alloy in an industry product, or the quantity or karat fineness of gold or gold alloy contained in the product, or the karat fineness, thickness, weight ratio, or manner of application of any gold or gold alloy plating, covering, or coating on any surface of an industry product or part thereof.
+-</P>
+-<P>(b) The following are examples of markings or descriptions that may be misleading: 
+-<SU>2</SU>
+-<FTREF/>
+-</P>
+-<FTNT>
+-<P>
+-<SU>2</SU> See § 23.4(c) for examples of acceptable markings and descriptions.</P></FTNT>
+-<P>(1) Use of the word “Gold” or any abbreviation, without qualification, to describe all or part of an industry product, which is not composed throughout of fine (24 karat) gold.
+-</P>
+-<P>(2) Use of the word “Gold” or any abbreviation to describe all or part of an industry product composed throughout of an alloy of gold, unless a correct designation of the karat fineness of the alloy immediately precedes the word “Gold” or its abbreviation, and such fineness designation is of at least equal conspicuousness.
+-</P>
+-<P>(3) Use of the word “Gold” or any abbreviation to describe all or part of an industry product that is not composed throughout of gold or a gold alloy, but is surface-plated or coated with gold alloy, unless the word “Gold” or its abbreviation is adequately qualified to indicate that the product or part is only surface-plated.
+-</P>
+-<P>(4) Use of the term “Gold Plate,” “Gold Plated,” or any abbreviation to describe all or part of an industry product unless such product or part contains a surface-plating of gold alloy, applied by any process, which is of such thickness and extent of surface coverage that reasonable durability is assured.
+-</P>
+-<P>(5) Use of the terms “Gold Filled,” “Rolled Gold Plate,” “Rolled Gold Plated,” “Gold Overlay,” or any abbreviation to describe all or part of an industry product unless such product or part contains a surface-plating of gold alloy applied by a mechanical process and of such thickness and extent of surface coverage that reasonable durability is assured, and unless the term is immediately preceded by a correct designation of the karat fineness of the alloy that is of at least equal conspicuousness as the term used.
+-</P>
+-<P>(6) Use of the terms “Gold Plate,” “Gold Plated,” “Gold Filled,” “Rolled Gold Plate,” “Rolled Gold Plated,” “Gold Overlay,” or any abbreviation to describe a product in which the layer of gold plating has been covered with a base metal (such as nickel), which is covered with a thin wash of gold, unless there is a disclosure that the primary gold coating is covered with a base metal, which is gold washed.
+-</P>
+-<P>(7) Use of the term “Gold Electroplate,” “Gold Electroplated,” or any abbreviation to describe all or part of an industry product unless such product or part is electroplated with gold or a gold alloy and such electroplating is of such karat fineness, thickness, and extent of surface coverage that reasonable durability is assured.
+-</P>
+-<P>(8) Use of any name, terminology, or other term to misrepresent that an industry product is equal or superior to, or different than, a known and established type of industry product with reference to its gold content or method of manufacture.
+-</P>
+-<P>(9) Use of the word “Gold” or any abbreviation, or of a quality mark implying gold content (e.g., 9 karat), to describe all or part of an industry product that is composed throughout of an alloy of gold of less than 10 karat fineness.
+-</P>
+-<NOTE>
+-<HED>Note to paragraph (<E T="01">b</E>) § 23.4:</HED>
+-<P>The provisions regarding the use of the word “Gold,” or any abbreviation, as described above, are applicable to “Duragold,” “Diragold,” “Noblegold,” “Goldine,” “Layered Gold,” or any words or terms of similar meaning.</P></NOTE>
+-<P>(c) The following are examples of markings and descriptions that are consistent with the principles described above:
+-</P>
+-<P>(1) An industry product or part thereof, composed throughout of an alloy of gold of not less than 10 karat fineness, may be marked and described as “Gold” when such word “Gold,” wherever appearing, is immediately preceded by a correct designation of the karat fineness of the alloy, and such karat designation is of equal conspicuousness as the word “Gold” (for example, “14 Karat Gold,” “14 K. Gold,” or “14 Kt. Gold”). Such product may also be marked and described by a designation of the karat fineness of the gold alloy unaccompanied by the word “Gold” (for example, “14 Karat,” “14 Kt.,” or “14 K.”).
+-</P>
+-<NOTE>
+-<HED>Note to paragraph (<E T="01">c</E>)(1):</HED>
+-<P>Use of the term “Gold” or any abbreviation to describe all or part of a product that is composed throughout of gold alloy, but contains a hollow center or interior, may mislead consumers, unless the fact that the product contains a hollow center is disclosed in immediate proximity to the term “Gold” or its abbreviation (for example, “14 Karat Gold-Hollow Center,” or “14 K. Gold Tubing,” when of a gold alloy tubing of such karat fineness). Such products should not be marked or described as “solid” or as being solidly of gold or of a gold alloy. For example, when the composition of such a product is 14 karat gold alloy, it should not be described or marked as either “14 Kt. Solid Gold” or as “Solid 14 Kt. Gold.”</P></NOTE>
+-<P>(2) An industry product or part thereof, on which there has been affixed on all significant surfaces, by any process, a coating, electroplating, or deposition by any means, of gold or gold alloy of not less than 10 karat fineness that is of substantial thickness, 
+-<SU>3</SU>
+-<FTREF/> and the minimum thickness throughout of which is equivalent to one-half micron (or approximately 20 millionths of an inch) of fine gold, 
+-<SU>4</SU>
+-<FTREF/> may be marked or described as “Gold Plate” or “Gold Plated,” or abbreviated, as, for example, G.P. The exact thickness of the plate may be marked on the item, if it is immediately followed by a designation of the karat fineness of the plating which is of equal conspicuousness as the term used (as, for example, “2 microns 12 K. gold plate” or “2µ 12 K. G.P.” for an item plated with 2 microns of 12 karat gold.)
+-</P>
+-<FTNT>
+-<P>
+-<SU>3</SU> The term <I>substantial thickness</I> means that all areas of the plating are of such thickness as to assure a durable coverage of the base metal to which it has been affixed. Since industry products include items having surfaces and parts of surfaces that are subject to different degrees of wear, the thickness of plating for all items or for different areas of the surface of individual items does not necessarily have to be uniform.</P></FTNT>
+-<FTNT>
+-<P>
+-<SU>4</SU> A product containing 1 micron (otherwise known as 1µ) of 12 karat gold is equivalent to one-half micron of 24 karat gold.</P></FTNT>
+-<NOTE>
+-<HED>Note to paragraph (<E T="01">c</E>)(2):</HED>
+-<P>If an industry product has a thicker coating or electroplating of gold or gold alloy on some areas than others, the minimum thickness of the plate should be marked.</P></NOTE>
+-<P>(3) An industry product or part thereof on which there has been affixed on all significant surfaces by soldering, brazing, welding, or other mechanical means, a plating of gold alloy of not less than 10 karat fineness and of substantial thickness 
+-<SU>5</SU>
+-<FTREF/> may be marked or described as “Gold Filled,” “Gold Overlay,” “Rolled Gold Plate,” or an adequate abbreviation, when such plating constitutes at least 
+-<FR>1/20</FR>th of the weight of the metal in the entire article and when the term is immediately preceded by a designation of the karat fineness of the plating which is of equal conspicuousness as the term used (for example, “14 Karat Gold Filled,” “14 Kt. Gold Filled,” “14 Kt. G.F.,” “14 Kt. Gold Overlay,” or “14K. R.G.P.”). When conforming to all such requirements except the specified minimum of 
+-<FR>1/20</FR>th of the weight of the metal in the entire article, the terms “Gold Overlay” and “Rolled Gold Plate” may be used when the karat fineness designation is immediately preceded by a fraction accurately disclosing the portion of the weight of the metal in the entire article accounted for by the plating, and when such fraction is of equal conspicuousness as the term used (for example, “
+-<FR>1/40</FR>th 12 Kt. Rolled Gold Plate” or “
+-<FR>1/40</FR> 12 Kt. R.G.P.”).
+-</P>
+-<FTNT>
+-<P>
+-<SU>5</SU> See footnote 3.</P></FTNT>
+-<P>(4) An industry product or part thereof, on which there has been affixed on all significant surfaces by an electrolytic process, an electroplating of gold, or of a gold alloy of not less than 10 karat fineness, which has a minimum thickness throughout equivalent to .175 microns (approximately 
+-<SU>7</SU>/<E T="52">1,000,000</E>ths of an inch) of fine gold, may be marked or described as “Gold Electroplate” or “Gold Electroplated,” or abbreviated, as, for example, “G.E.P.” When the electroplating meets the minimum fineness but not the minimum thickness specified above, the marking or description may be “Gold Flashed” or “Gold Washed.” When the electroplating is of the minimum fineness specified above and of a minimum thickness throughout equivalent to two and one half (2
+-<FR>1/2</FR>) microns (or approximately 
+-<SU>100</SU>/<E T="52">1,000,000</E>ths of an inch) of fine gold, the marking or description may be “Heavy Gold Electroplate” or “Heavy Gold Electroplated.” When electroplatings qualify for the term “Gold Electroplate” (or “Gold Electroplated”), or the term “Heavy Gold Electroplate” (or “Heavy Gold Electroplated”), and have been applied by use of a particular kind of electrolytic process, the marking may be accompanied by identification of the process used, as for example, “Gold Electroplated (X Process)” or “Heavy Gold Electroplated (Y Process).”
+-</P>
+-<P>(d) The provisions of this section relating to markings and descriptions of industry products and parts thereof are subject to the applicable tolerances of the National Stamping Act or any amendment thereof. 
+-<SU>6</SU>
+-<FTREF/>
+-</P>
+-<FTNT>
+-<P>
+-<SU>6</SU> Under the National Stamping Act, articles or parts made of gold or of gold alloy that contain no solder have a permissible tolerance of three parts per thousand. If the part tested contains solder, the permissible tolerance is seven parts per thousand. For full text, see 15 U.S.C. 295, <I>et seq.</I></P></FTNT>
+-<NOTE>
+-<HED>Note 4 to paragraph (<E T="01">d</E>):</HED>
+-<P>Exemptions recognized in the assay of karat gold industry products and in the assay of gold filled, gold overlay, and rolled gold plate industry products, and not to be considered in any assay for quality, are listed in the appendix.</P></NOTE>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.5" TYPE="SECTION">
+-<HEAD>§ 23.5   Misuse of the word “vermeil.”</HEAD>
+-<P>(a) It is unfair or deceptive to represent, directly or by implication, that an industry product is “vermeil” if such mark or description misrepresents the product's true composition.
+-</P>
+-<P>(b) An industry product may be described or marked as “vermeil” if it consists of a base of sterling silver coated or plated on all significant surfaces with gold, or gold alloy of not less than 10 karat fineness, that is of substantial thickness 
+-<SU>7</SU>
+-<FTREF/> and a minimum thickness throughout equivalent to two and one half (2
+-<FR>1/2</FR>) microns (or approximately 
+-<SU>100</SU>/<E T="52">1,000,000</E>ths of an inch) of fine gold.
+-</P>
+-<FTNT>
+-<P>
+-<SU>7</SU> See footnote 3.</P></FTNT>
+-<NOTE>
+-<HED>Note 1 to § 23.5:</HED>
+-<P>It is unfair or deceptive to use the term “vermeil” to describe a product in which the sterling silver has been covered with a base metal (such as nickel) plated with gold unless there is a disclosure that the sterling silver is covered with a base metal that is plated with gold.</P></NOTE>
+-<NOTE>
+-<HED>Note 2 to § 23.5:</HED>
+-<P>Exemptions recognized in the assay of gold filled, gold overlay, and rolled gold plate industry products are listed in the appendix.</P></NOTE>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.6" TYPE="SECTION">
+-<HEAD>§ 23.6   Misrepresentation as to silver content.</HEAD>
+-<P>(a) It is unfair or deceptive to misrepresent that an industry product contains silver, or to misrepresent an industry product as having a silver content, plating, electroplating, or coating.
+-</P>
+-<P>(b) It is unfair or deceptive to mark, describe, or otherwise represent all or part of an industry product as “silver,” “solid silver,” “Sterling Silver,” “Sterling,” or the abbreviation “Ster.” unless it is at least 
+-<FR>925/1,000</FR>ths pure silver.
+-</P>
+-<P>(c) It is unfair or deceptive to mark, describe, or otherwise represent all or part of an industry product as “coin” or “coin silver” unless it is at least 
+-<FR>900/1,000</FR>ths pure silver.
+-</P>
+-<P>(d) It is unfair or deceptive to mark, describe, or otherwise represent all or part of an industry product as being plated or coated with silver unless all significant surfaces of the product or part contain a plating or coating of silver that is of substantial thickness. 
+-<SU>8</SU>
+-<FTREF/>
+-</P>
+-<FTNT>
+-<P>
+-<SU>8</SU> See footnote 3.</P></FTNT>
+-<P>(e) The provisions of this section relating to markings and descriptions of industry products and parts thereof are subject to the applicable tolerances of the National Stamping Act or any amendment thereof. 
+-<SU>9</SU>
+-<FTREF/>
+-</P>
+-<FTNT>
+-<P>
+-<SU>9</SU> Under the National Stamping Act, sterling silver articles or parts that contain no solder have a permissible tolerance of four parts per thousand. If the part tested contains solder, the permissible tolerance is ten parts per thousand. For full text, see 15 U.S.C. 294, <I>et seq.</I></P></FTNT>
+-<NOTE>
+-<HED>Note 1 to § 23.6:</HED>
+-<P>The National Stamping Act provides that silverplated articles shall not “be stamped, branded, engraved or imprinted with the word ‘sterling’ or the word ‘coin,’ either alone or in conjunction with other words or marks.” 15 U.S.C. 297(a).</P></NOTE>
+-<NOTE>
+-<HED>Note 2 to § 23.6:</HED>
+-<P>Exemptions recognized in the assay of silver industry products are listed in the appendix.</P></NOTE>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.7" TYPE="SECTION">
+-<HEAD>§ 23.7   Misuse of the words “platinum,” “iridium,” “palladium,” “ruthenium,” “rhodium,” and “osmium.”</HEAD>
+-<P>(a) It is unfair or deceptive to use the words “platinum,” “iridium,” “palladium,” “ruthenium,” “rhodium,” and “osmium,” or any abbreviation to mark or describe all or part of an industry product if such marking or description misrepresents the product's true composition. The Platinum Group Metals (PGM) are Platinum, Iridium, Palladium, Ruthenium, Rhodium, and Osmium.
+-</P>
+-<P>(b) The following are examples of markings or descriptions that may be misleading: 
+-<SU>10</SU>
+-<FTREF/>
+-</P>
+-<FTNT>
+-<P>
+-<SU>10</SU> See paragraph (c) of this section for examples of acceptable markings and descriptions.</P></FTNT>
+-<P>(1) Use of the word “Platinum” or any abbreviation, without qualification, to describe all or part of an industry product that is not composed throughout of 950 parts per thousand pure Platinum.
+-</P>
+-<P>(2) Use of the word “Platinum” or any abbreviation accompanied by a number indicating the parts per thousand of pure Platinum contained in the product without mention of the number of parts per thousand of other PGM contained in the product, to describe all or part of an industry product that is not composed throughout of at least 850 parts per thousand pure platinum, for example, “600Plat.”
+-</P>
+-<P>(3) Use of the word “Platinum” or any abbreviation thereof, to mark or describe any product that is not composed throughout of at least 500 parts per thousand pure Platinum.
+-</P>
+-<P>(4) Use of the word “Platinum,” or any abbreviation accompanied by a number or percentage indicating the parts per thousand of pure Platinum contained in the product, to describe all or part of an industry product that contains at least 500 parts per thousand, but less than 850 parts per thousand, pure Platinum, and does not contain at least 950 parts per thousand PGM (for example, “585 Plat.”) without a clear and conspicuous disclosure, immediately following the name or description of such product:
+-</P>
+-<P>(i) Of the full composition of the product (by name and not abbreviation) and percentage of each metal; and
+-</P>
+-<P>(ii) That the product may not have the same attributes or properties as traditional platinum products. <I>Provided, however,</I> that the marketer need not make disclosure under § 23.7(b)(4)(ii), if the marketer has competent and reliable scientific evidence that such product does not differ materially from any one product containing at least 850 parts per thousand pure Platinum with respect to the following attributes or properties: durability, luster, density, scratch resistance, tarnish resistance, hypoallergenicity, ability to be resized or repaired, retention of precious metal over time, and any other attribute or property material to consumers.
+-</P>
+-<NOTE>
+-<HED>Note to paragraph (<E T="01">b</E>)(4):</HED>
+-<P>When using percentages to qualify platinum representations, marketers should convert the amount in parts per thousand to a percentage that is accurate to the first decimal place (<I>e.g.,</I> 58.5% Platinum, 41.5% Cobalt).</P></NOTE>
+-<P>(c) The following are examples of markings and descriptions that are not considered unfair or deceptive:
+-</P>
+-<P>(1) The following abbreviations for each of the PGM may be used for quality marks on articles: “Plat.” or “Pt.” for Platinum; “Irid.” or “Ir.” for Iridium; “Pall.” or “Pd.” for Palladium; “Ruth.” or “Ru.” for Ruthenium; “Rhod.” or “Rh.” for Rhodium; and “Osmi.” or “Os.” for Osmium.
+-</P>
+-<P>(2) An industry product consisting of at least 950 parts per thousand pure Platinum may be marked or described as “Platinum.”
+-</P>
+-<P>(3) An industry product consisting of 850 parts per thousand pure Platinum, 900 parts per thousand pure Platinum, or 950 parts per thousand pure Platinum may be marked “Platinum,” provided that the Platinum marking is preceded by a number indicating the amount in parts per thousand of pure Platinum (for industry products consisting of 950 parts per thousand pure Platinum, the marking described in § 23.7(b)(2) above is also appropriate). Thus, the following markings may be used: “950Pt.,” “950Plat.,” “900Pt.,” “900Plat.,” “850Pt.,” or “850Plat.”
+-</P>
+-<P>(4) An industry product consisting of at least 950 parts per thousand PGM, and of at least 500 parts per thousand pure Platinum, may be marked “Platinum,” provided that the mark of each PGM constituent is preceded by a number indicating the amount in parts per thousand of each PGM, as for example, “600Pt.350Ir.,” “600Plat.350Irid.,” or “550Pt.350Pd.50Ir.,” “550Plat.350Pall.50Irid.”
+-</P>
+-<P>(5) An industry product consisting of at least 500 parts per thousand, but less than 850 parts per thousand, pure Platinum, and not consisting of at least 950 parts per thousand PGM, may be marked or stamped accurately, with a quality marking on the article, using parts per thousand and standard chemical abbreviations (<I>e.g.,</I> 585 Pt., 415 Co.).
+-</P>
+-<NOTE>
+-<HED>Note to § 23.7:</HED>
+-<P>Exemptions recognized in the assay of platinum industry products are listed in appendix A of this part.</P></NOTE>
+-<CITA TYPE="N">[62 FR 16675, Apr. 8, 1997, as amended at 75 FR 81453, Dec. 28, 2010]
+-
+-
+-</CITA>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.8" TYPE="SECTION">
+-<HEAD>§ 23.8   Misrepresentation as to content of pewter.</HEAD>
+-<P>(a) It is unfair or deceptive to mark, describe, or otherwise represent all or part of an industry product as “Pewter” or any abbreviation if such mark or description misrepresents the product's true composition.
+-</P>
+-<P>(b) An industry product or part thereof may be described or marked as “Pewter” or any abbreviation if it consists of at least 900 parts per 1000 Grade A Tin, with the remainder composed of metals appropriate for use in pewter.
+-
+-
+-</P>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.9" TYPE="SECTION">
+-<HEAD>§ 23.9   Additional guidance for the use of quality marks.</HEAD>
+-<P>As used in these guides, the term <I>quality mark</I> means any letter, figure, numeral, symbol, sign, word, or term, or any combination thereof, that has been stamped, embossed, inscribed, or otherwise placed on any industry product and which indicates or suggests that any such product is composed throughout of any precious metal or any precious metal alloy or has a surface or surfaces on which there has been plated or deposited any precious metal or precious metal alloy. Included are the words “gold,” “karat,” “carat,” “silver,” “sterling,” “vermeil,” “platinum,” “iridium,” “palladium,” “ruthenium,” “rhodium,” or “osmium,” or any abbreviations thereof, whether used alone or in conjunction with the words “filled,” “plated,” “overlay,” or “electroplated,” or any abbreviations thereof. Quality markings include those in which the words or terms “gold,” “karat,” “silver,” “vermeil,” “platinum” (or platinum group metals), or their abbreviations are included, either separately or as suffixes, prefixes, or syllables.
+-</P>
+-<P>(a) <I>Deception as to applicability of marks.</I> (1) If a quality mark on an industry product is applicable to only part of the product, the part of the product to which it is applicable (or inapplicable) should be disclosed when, absent such disclosure, the location of the mark misrepresents the product or part's true composition.
+-</P>
+-<P>(2) If a quality mark is applicable to only part of an industry product, but not another part which is of similar surface appearance, each quality mark should be closely accompanied by an identification of the part or parts to which the mark is applicable.
+-</P>
+-<P>(b) <I>Deception by reason of difference in the size of letters or words in a marking or markings.</I> It is unfair or deceptive to place a quality mark on a product in which the words or letters appear in greater size than other words or letters of the mark, or when different markings placed on the product have different applications and are in different sizes, when the net impression of any such marking would be misleading as to the metallic composition of all or part of the product. (An example of improper marking would be the marking of a gold electroplated product with the word “electroplate” in small type and the word “gold” in larger type, with the result that purchasers and prospective purchasers of the product might only observe the word “gold.”)
+-</P>
+-<NOTE>
+-<HED>Note 1 to § 23.9:</HED>
+-<P>Legibility of markings. If a quality mark is engraved or stamped on an industry product, or is printed on a tag or label attached to the product, the quality mark should be of sufficient size type as to be legible to persons of normal vision, should be so placed as likely to be observed by purchasers, and should be so attached as to remain thereon until consumer purchase.</P></NOTE>
+-<NOTE>
+-<HED>Note 2 to § 23.9:</HED>
+-<P>Disclosure of identity of manufacturers, processors, or distributors. The National Stamping Act provides that any person, firm, corporation, or association, being a manufacturer or dealer subject to section 294 of the Act, who applies or causes to be applied a quality mark, or imports any article bearing a quality mark “which indicates or purports to indicate that such article is made in whole or in part of gold or silver or of an alloy of either metal” shall apply to the article the trademark or name of such person. 15 U.S.C. 297.</P></NOTE>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.10" TYPE="SECTION">
+-<HEAD>§ 23.10   Misuse of “corrosion proof,” “noncorrosive,” “corrosion resistant,” “rust proof,” “rust resistant,” etc.</HEAD>
+-<P>(a) It is unfair or deceptive to:
+-</P>
+-<P>(1) Use the terms “corrosion proof,” “noncorrosive,” “rust proof,” or any other term of similar meaning to describe an industry product unless all parts of the product will be immune from rust and other forms of corrosion during the life expectancy of the product; or
+-</P>
+-<P>(2) Use the terms “corrosion resistant,” “rust resistant,” or any other term of similar meaning to describe an industry product unless all parts of the product are of such composition as to not be subject to material damage by corrosion or rust during the major portion of the life expectancy of the product under normal conditions of use.
+-</P>
+-<P>(b) Among the metals that may be considered as corrosion (and rust) resistant are: Pure nickel; Gold alloys of not less than 10 Kt. fineness; and Austenitic stainless steels.
+-
+-
+-</P>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.11" TYPE="SECTION">
+-<HEAD>§ 23.11   Definition and misuse of the word “diamond.”</HEAD>
+-<P>(a) A diamond is a natural mineral consisting essentially of pure carbon crystallized in the isometric system. It is found in many colors. Its hardness is 10; its specific gravity is approximately 3.52; and it has a refractive index of 2.42.
+-</P>
+-<P>(b) It is unfair or deceptive to use the unqualified word “diamond” to describe or identify any object or product not meeting the requirements specified in the definition of diamond provided above, or which, though meeting such requirements, has not been symmetrically fashioned with at least seventeen (17) polished facets.
+-</P>
+-<NOTE>
+-<HED>Note 1 to paragraph (<E T="01">b</E>):</HED>
+-<P>It is unfair or deceptive to represent, directly or by implication, that industrial grade diamonds or other non-jewelry quality diamonds are of jewelry quality.</P></NOTE>
+-<P>(c) The following are examples of descriptions that are not considered unfair or deceptive:
+-</P>
+-<P>(1) The use of the words “rough diamond” to describe or designate uncut or unfaceted objects or products satisfying the definition of diamond provided above; or
+-</P>
+-<P>(2) The use of the word “diamond” to describe or designate objects or products satisfying the definition of diamond but which have not been symmetrically fashioned with at least seventeen (17) polished facets when in immediate conjunction with the word “diamond” there is either a disclosure of the number of facets and shape of the diamond or the name of a type of diamond that denotes shape and that usually has less than seventeen (17) facets (e.g., “rose diamond”).
+-</P>
+-<NOTE>
+-<HED>Note 2 to paragraph (<E T="01">c</E>):</HED>
+-<P>Additional guidance about imitation and laboratory-created diamond representations and misuse of words “gem,” “real,” “genuine,” “natural,” etc., are set forth in §§ 23.23, 23.24, and 23.25.</P></NOTE>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.12" TYPE="SECTION">
+-<HEAD>§ 23.12   Misuse of the words “flawless,” “perfect,” etc.</HEAD>
+-<P>(a) It is unfair or deceptive to use the word “flawless” to describe any diamond that discloses flaws, cracks, inclusions, carbon spots, clouds, internal lasering, or other blemishes or imperfections of any sort when examined under a corrected magnifier at 10-power, with adequate illumination, by a person skilled in diamond grading.
+-</P>
+-<P>(b) It is unfair or deceptive to use the word “perfect,” or any representation of similar meaning, to describe any diamond unless the diamond meets the definition of “flawless” and is not of inferior color or make.
+-</P>
+-<P>(c) It is unfair or deceptive to use the words “flawless” or “perfect” to describe a ring or other article of jewelry having a “flawless” or “perfect” principal diamond or diamonds, and supplementary stones that are not of such quality, unless there is a disclosure that the description applies only to the principal diamond or diamonds.
+-
+-
+-</P>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.13" TYPE="SECTION">
+-<HEAD>§ 23.13   Disclosure of treatments to diamonds.</HEAD>
+-<P>A diamond is a gemstone product. Treatments to diamonds should be disclosed in the manner prescribed in § 23.22 of these guides, Disclosure of treatments to gemstones.
+-</P>
+-<CITA TYPE="N">[65 FR 78743, Dec. 15, 2000]
+-
+-
+-</CITA>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.14" TYPE="SECTION">
+-<HEAD>§ 23.14   Misuse of the term “blue white.”</HEAD>
+-<P>It is unfair or deceptive to use the term “blue white” or any representation of similar meaning to describe any diamond that under normal, north daylight or its equivalent shows any color or any trace of any color other than blue or bluish.
+-
+-
+-</P>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.15" TYPE="SECTION">
+-<HEAD>§ 23.15   Misuse of the term “properly cut,” etc.</HEAD>
+-<P>It is unfair or deceptive to use the terms “properly cut,” “proper cut,” “modern cut,” or any representation of similar meaning to describe any diamond that is lopsided, or is so thick or so thin in depth as to detract materially from the brilliance of the stone.
+-</P>
+-<NOTE>
+-<HED>Note to § 23.15:</HED>
+-<P>Stones that are commonly called “fisheye” or “old mine” should not be described as “properly cut,” “modern cut,” etc.</P></NOTE>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.16" TYPE="SECTION">
+-<HEAD>§ 23.16   Misuse of the words “brilliant” and “full cut.”</HEAD>
+-<P>It is unfair or deceptive to use the unqualified expressions “brilliant,” “brilliant cut,” or “full cut” to describe, identify, or refer to any diamond except a round diamond that has at least thirty-two (32) facets plus the table above the girdle and at least twenty-four (24) facets below.
+-</P>
+-<NOTE>
+-<HED>Note to § 23.16:</HED>
+-<P>Such terms should not be applied to single or rose-cut diamonds. They may be applied to emerald-(rectangular) cut, pear-shaped, heart-shaped, oval-shaped, and marquise-(pointed oval) cut diamonds meeting the above-stated facet requirements when, in immediate conjunction with the term used, the form of the diamond is disclosed.</P></NOTE>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.17" TYPE="SECTION">
+-<HEAD>§ 23.17   Misrepresentation of weight and “total weight.”</HEAD>
+-<P>(a) It is unfair or deceptive to misrepresent the weight of a diamond.
+-</P>
+-<P>(b) It is unfair or deceptive to use the word “point” or any abbreviation in any representation, advertising, marking, or labeling to describe the weight of a diamond, unless the weight is also stated as decimal parts of a carat (e.g., 25 points or .25 carat).
+-</P>
+-<NOTE>
+-<HED>Note 1 to paragraph (<E T="01">b</E>):</HED>
+-<P>A carat is a standard unit of weight for a diamond and is equivalent to 200 milligrams (
+-<FR>1/5</FR> gram). A point is one one hundredth (
+-<FR>1/100</FR>) of a carat.</P></NOTE>
+-<P>(c) If diamond weight is stated as decimal parts of a carat (e.g., .47 carat), the stated figure should be accurate to the last decimal place. If diamond weight is stated to only one decimal place (e.g., .5 carat), the stated figure should be accurate to the second decimal place (e.g., “.5 carat” could represent a diamond weight between .495-.504).
+-</P>
+-<P>(d) If diamond weight is stated as fractional parts of a carat, a conspicuous disclosure of the fact that the diamond weight is not exact should be made in close proximity to the fractional representation and a disclosure of a reasonable range of weight for each fraction (or the weight tolerance being used) should also be made.
+-</P>
+-<NOTE>
+-<HED>Note to paragraph (<E T="01">d</E>):</HED>
+-<P>When fractional representations of diamond weight are made, as described in paragraph d of this section, in catalogs or other printed materials, the disclosure of the fact that the actual diamond weight is within a specified range should be made conspicuously on every page where a fractional representation is made. Such disclosure may refer to a chart or other detailed explanation of the actual ranges used. For example, “Diamond weights are not exact; see chart on p.X for ranges.”</P></NOTE>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.18" TYPE="SECTION">
+-<HEAD>§ 23.18   Definitions of various pearls.</HEAD>
+-<P>As used in these guides, the terms set forth below have the following meanings:
+-</P>
+-<P>(a) <I>Pearl:</I> A calcareous concretion consisting essentially of alternating concentric layers of carbonate of lime and organic material formed within the body of certain mollusks, the result of an abnormal secretory process caused by an irritation of the mantle of the mollusk following the intrusion of some foreign body inside the shell of the mollusk, or due to some abnormal physiological condition in the mollusk, neither of which has in any way been caused or induced by humans.
+-</P>
+-<P>(b) <I>Cultured pearl:</I> The composite product created when a nucleus (usually a sphere of calcareous mollusk shell) planted by humans inside the shell or in the mantle of a mollusk is coated with nacre by the mollusk.
+-</P>
+-<P>(c) <I>Imitation pearl:</I> A manufactured product composed of any material or materials that simulate in appearance a pearl or cultured pearl.
+-</P>
+-<P>(d) <I>Seed pearl:</I> A small pearl, as defined in (a), that measures approximately two millimeters or less.
+-
+-
+-</P>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.19" TYPE="SECTION">
+-<HEAD>§ 23.19   Misuse of the word “pearl.”</HEAD>
+-<P>(a) It is unfair or deceptive to use the unqualified word “pearl” or any other word or phrase of like meaning to describe, identify, or refer to any object or product that is not in fact a pearl, as defined in § 23.18(a).
+-</P>
+-<P>(b) It is unfair or deceptive to use the word “pearl” to describe, identify, or refer to a cultured pearl unless it is immediately preceded, with equal conspicuousness, by the word “cultured” or “cultivated,” or by some other word or phrase of like meaning, so as to indicate definitely and clearly that the product is not a pearl.
+-</P>
+-<P>(c) It is unfair or deceptive to use the word “pearl” to describe, identify, or refer to an imitation pearl unless it is immediately preceded, with equal conspicuousness, by the word “artificial,” “imitation,” or “simulated,” or by some other word or phrase of like meaning, so as to indicate definitely and clearly that the product is not a pearl.
+-</P>
+-<P>(d) It is unfair or deceptive to use the terms “faux pearl,” “fashion pearl,” “Mother of Pearl,” or any other such term to describe or qualify an imitation pearl product unless it is immediately preceded, with equal conspicuousness, by the word “artificial,” “imitation,” or “simulated,” or by some other word or phrase of like meaning, so as to indicate definitely and clearly that the product is not a pearl.
+-
+-
+-</P>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.20" TYPE="SECTION">
+-<HEAD>§ 23.20   Misuse of terms such as “cultured pearl,” “seed pearl,” “Oriental pearl,” “natura,” “kultured,” “real,” “gem,” “synthetic,” and regional designations.</HEAD>
+-<P>(a) It is unfair or deceptive to use the term “cultured pearl,” “cultivated pearl,” or any other word, term, or phrase of like meaning to describe, identify, or refer to any imitation pearl.
+-</P>
+-<P>(b) It is unfair or deceptive to use the term “seed pearl” or any word, term, or phrase of like meaning to describe, identify, or refer to a cultured or an imitation pearl, without using the appropriate qualifying term “cultured” (e.g., “cultured seed pearl”) or “simulated,” “artificial,” or “imitation” (e.g., “imitation seed pearl”).
+-</P>
+-<P>(c) It is unfair or deceptive to use the term “Oriental pearl” or any word, term, or phrase of like meaning to describe, identify, or refer to any industry product other than a pearl taken from a salt water mollusk and of the distinctive appearance and type of pearls obtained from mollusks inhabiting the Persian Gulf and recognized in the jewelry trade as Oriental pearls.
+-</P>
+-<P>(d) It is unfair or deceptive to use the word “Oriental” to describe, identify, or refer to any cultured or imitation pearl.
+-</P>
+-<P>(e) It is unfair or deceptive to use the word “natura,” “natural,” “nature's,” or any word, term, or phrase of like meaning to describe, identify, or refer to a cultured or imitation pearl. It is unfair or deceptive to use the term “organic” to describe, identify, or refer to an imitation pearl, unless the term is qualified in such a way as to make clear that the product is not a natural or cultured pearl.
+-</P>
+-<P>(f) It is unfair or deceptive to use the term “kultured,” “semi-cultured pearl,” “cultured-like,” “part-cultured,” “pre-mature cultured pearl,” or any word, term, or phrase of like meaning to describe, identify, or refer to an imitation pearl.
+-</P>
+-<P>(g) It is unfair or deceptive to use the term “South Sea pearl” unless it describes, identifies, or refers to a pearl that is taken from a salt water mollusk of the Pacific Ocean South Sea Islands, Australia, or Southeast Asia. It is unfair or deceptive to use the term “South Sea cultured pearl” unless it describes, identifies, or refers to a cultured pearl formed in a salt water mollusk of the Pacific Ocean South Sea Islands, Australia, or Southeast Asia.
+-</P>
+-<P>(h) It is unfair or deceptive to use the term “Biwa cultured pearl” unless it describes, identifies, or refers to cultured pearls grown in fresh water mollusks in the lakes and rivers of Japan.
+-</P>
+-<P>(i) It is unfair or deceptive to use the word “real,” “genuine,” “precious,” or any word, term, or phrase of like meaning to describe, identify, or refer to any imitation pearl.
+-</P>
+-<P>(j) It is unfair or deceptive to use the word “gem” to describe, identify, or refer to a pearl or cultured pearl that does not possess the beauty, symmetry, rarity, and value necessary for qualification as a gem.
+-</P>
+-<NOTE>
+-<HED>Note to paragraph (<E T="01">j</E>):</HED>
+-<P>Use of the word “gem” with respect to cultured pearls should be avoided since few cultured pearls possess the necessary qualifications to properly be termed “gems.” Imitation pearls should not be described as “gems.”</P></NOTE>
+-<P>(k) It is unfair or deceptive to use the word “synthetic” or similar terms to describe cultured or imitation pearls.
+-</P>
+-<P>(l) It is unfair or deceptive to use the terms “Japanese Pearls,” “Chinese Pearls,” “Mallorca Pearls,” or any regional designation to describe, identify, or refer to any cultured or imitation pearl, unless the term is immediately preceded, with equal conspicuousness, by the word “cultured,” “artificial,” “imitation,” or “simulated,” or by some other word or phrase of like meaning, so as to indicate definitely and clearly that the product is a cultured or imitation pearl.
+-
+-
+-</P>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.21" TYPE="SECTION">
+-<HEAD>§ 23.21   Misrepresentation as to cultured pearls.</HEAD>
+-<P>It is unfair or deceptive to misrepresent the manner in which cultured pearls are produced, the size of the nucleus artificially inserted in the mollusk and included in cultured pearls, the length of time that such products remained in the mollusk, the thickness of the nacre coating, the value and quality of cultured pearls as compared with the value and quality of pearls and imitation pearls, or any other material matter relating to the formation, structure, properties, characteristics, and qualities of cultured pearls.
+-
+-
+-</P>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.22" TYPE="SECTION">
+-<HEAD>§ 23.22   Disclosure of treatments to gemstones.</HEAD>
+-<P>It is unfair or deceptive to fail to disclose that a gemstone has been treated if: 
+-</P>
+-<P>(a) The treatment is not permanent. The seller should disclose that the gemstone has been treated and that the treatment is or may not be permanent; 
+-</P>
+-<P>(b) The treatment creates special care requirements for the gemstone. The seller should disclose that the gemstone has been treated and has special care requirements. It is also recommended that the seller disclose the special care requirements to the purchaser; 
+-</P>
+-<P>(c) The treatment has a significant effect on the stone's value. The seller should disclose that the gemstone has been treated.
+-</P>
+-<NOTE>
+-<HED>Note to § 23.22:</HED>
+-<P>The disclosures outlined in this section are applicable to sellers at every level of trade, as defined in § 23.0(b) of these Guides, and they may be made at the point of sale prior to sale; except that where a jewelry product can be purchased without personally viewing the product, (e.g., direct mail catalogs, online services, televised shopping programs) disclosure should be made in the solicitation for or description of the product.</P></NOTE>
+-<CITA TYPE="N">[65 FR 78743, Dec. 15, 2000]
+-
+-
+-</CITA>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.23" TYPE="SECTION">
+-<HEAD>§ 23.23   Misuse of the words “ruby,” “sapphire,” “emerald,” “topaz,” “stone,” “birthstone,” “gemstone,” etc.</HEAD>
+-<P>(a) It is unfair or deceptive to use the unqualified words “ruby,” “sapphire,” “emerald,” “topaz,” or the name of any other precious or semi-precious stone to describe any product that is not in fact a natural stone of the type described.
+-</P>
+-<P>(b) It is unfair or deceptive to use the word “ruby,” “sapphire,” “emerald,” “topaz,” or the name of any other precious or semi-precious stone, or the word “stone,” “birthstone,” “gemstone,” or similar term to describe a laboratory-grown, laboratory-created, [manufacturer name]-created, synthetic, imitation, or simulated stone, unless such word or name is immediately preceded with equal conspicuousness by the word “laboratory-grown,” “laboratory-created,” “[manufacturer name]-created,” “synthetic,” or by the word “imitation” or “simulated,” so as to disclose clearly the nature of the product and the fact it is not a natural gemstone.
+-</P>
+-<NOTE>
+-<HED>Note to paragraph (<E T="01">h</E>):</HED>
+-<P>The use of the word “faux” to describe a laboratory-created or imitation stone is not an adequate disclosure that the stone is not natural.</P></NOTE>
+-<P>(c) It is unfair or deceptive to use the word “laboratory-grown,” “laboratory-created,” “[manufacturer name]-created,” or “synthetic” with the name of any natural stone to describe any industry product unless such industry product has essentially the same optical, physical, and chemical properties as the stone named.
+-
+-
+-</P>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.24" TYPE="SECTION">
+-<HEAD>§ 23.24   Misuse of the words “real,” “genuine,” “natural,” “precious,” etc.</HEAD>
+-<P>It is unfair or deceptive to use the word “real,” “genuine,” “natural,” “precious,” “semi-precious,” or similar terms to describe any industry product that is manufactured or produced artificially.
+-
+-
+-</P>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.25" TYPE="SECTION">
+-<HEAD>§ 23.25   Misuse of the word “gem.”</HEAD>
+-<P>(a) It is unfair or deceptive to use the word “gem” to describe, identify, or refer to a ruby, sapphire, emerald, topaz, or other industry product that does not possess the beauty, symmetry, rarity, and value necessary for qualification as a gem.
+-</P>
+-<P>(b) It is unfair or deceptive to use the word “gem” to describe any laboratory-created industry product unless the product meets the requirements of paragraph (a) of this section and unless such word is immediately accompanied, with equal conspicuousness, by the word “laboratory-grown,” “laboratory-created,” or “[manufacturer-name]-created,” “synthetic,” or by some other word or phrase of like meaning, so as to clearly disclose that it is not a natural gem.
+-</P>
+-<NOTE>
+-<HED>Note to § 23.25:</HED>
+-<P>In general, use of the word “gem” with respect to laboratory-created stones should be avoided since few laboratory-created stones possess the necessary qualifications to properly be termed “gems.” Imitation diamonds and other imitation stones should not be described as “gems.” Not all diamonds or natural stones, including those classified as precious stones, possess the necessary qualifications to be properly termed “gems.”</P></NOTE>
+-</DIV8>
+-
+-
+-<DIV8 N="§ 23.26" TYPE="SECTION">
+-<HEAD>§ 23.26   Misuse of the words “flawless,” “perfect,” etc.</HEAD>
+-<P>(a) It is unfair or deceptive to use the word “flawless” as a quality description of any gemstone that discloses blemishes, inclusions, or clarity faults of any sort when examined under a corrected magnifier at 10-power, with adequate illumination, by a person skilled in gemstone grading.
+-</P>
+-<P>(b) It is unfair or deceptive to use the word “perfect” or any representation of similar meaning to describe any gemstone unless the gemstone meets the definition of “flawless” and is not of inferior color or make.
+-</P>
+-<P>(c) It is unfair or deceptive to use the word “flawless,” “perfect,” or any representation of similar meaning to describe any imitation gemstone.
+-
+-
+-</P>
+-</DIV8>
+-
+-
+-<DIV9 N="Appendix to" TYPE="APPENDIX">
+-<HEAD>Appendix to Part 23 - Exemptions Recognized in the Assay for Quality of Gold Alloy, Gold Filled, Gold Overlay, Rolled Gold Plate, Silver, and Platinum Industry Products
+-</HEAD>
+-<P>(a) Exemptions recognized in the industry and not to be considered in any assay for quality of a karat gold industry product include springs, posts, and separable backs of lapel buttons, posts and nuts for attaching interchangeable ornaments, metallic parts completely and permanently encased in a nonmetallic covering, field pieces and bezels for lockets, 
+-<SU>1</SU>
+-<FTREF/> and wire pegs or rivets used for applying mountings and other ornaments, which mountings or ornaments shall be of the quality marked.
+-</P>
+-<FTNT>
+-<P>
+-<SU>1</SU> Field pieces of lockets are those inner portions used as frames between the inside edges of the locket and the spaces for holding pictures. Bezels are the separable inner metal rings to hold the pictures in place.</P></FTNT>
+-<NOTE>
+-<HED>Note:</HED>
+-<P>Exemptions recognized in the industry and not to be considered in any assay for quality of a karat gold optical product include: the hinge assembly (barrel or other special types such as are customarily used in plastic frames); washers, bushings, and nuts of screw assemblies; dowels; springs for spring shoe straps; metal parts permanently encased in a non-metallic covering; and for oxfords, 
+-<SU>2</SU>
+-<FTREF/> coil and joint springs.</P></NOTE>
+-<FTNT>
+-<P>
+-<SU>2</SU> Oxfords are a form of eyeglasses where a flat spring joins the two eye rims and the tension it exerts on the nose serves to hold the unit in place. Oxfords are also referred to as pince nez.</P></FTNT>
+-<P>(b) Exemptions recognized in the industry and not to be considered in any assay for quality of a gold filled, gold overlay and rolled gold plate industry product, other than watchcases, include joints, catches, screws, pin stems, pins of scarf pins, hat pins, etc., field pieces and bezels for lockets, posts and separate backs of lapel buttons, bracelet and necklace snap tongues, springs, and metallic parts completely and permanently encased in a nonmetallic covering.
+-</P>
+-<NOTE>
+-<HED>Note:</HED>
+-<P>Exemptions recognized in the industry and not to be considered in any assay for quality of a gold filled, gold overlay and rolled gold plate optical product include: screws; the hinge assembly (barrel or other special types such as are customarily used in plastic frames); washers, bushings, tubes and nuts of screw assemblies; dowels; pad inserts; springs for spring shoe straps, cores and/or inner windings of comfort cable temples; metal parts permanently encased in a non-metallic covering; and for oxfords, the handle and catch.</P></NOTE>
+-<P>(c) Exemptions recognized in the industry and not to be considered in any assay for quality of a silver industry product include screws, rivets, springs, spring pins for wrist watch straps; posts and separable backs of lapel buttons; wire pegs, posts, and nuts used for applying mountings or other ornaments, which mountings or ornaments shall be of the quality marked; pin stems (e.g., of badges, brooches, emblem pins, hat pins, and scarf pins, etc.); levers for belt buckles; blades and skeletons of pocket knives; field pieces and bezels for lockets; bracelet and necklace snap tongues; any other joints, catches, or screws; and metallic parts completely and permanently encased in a nonmetallic covering.
+-</P>
+-<P>(d) Exemptions recognized in the industry and not to be considered in any assay for quality of an industry product of silver in combination with gold include joints, catches, screws, pin stems, pins of scarf pins, hat pins, etc., posts and separable backs of lapel buttons, springs, and metallic parts completely and permanently encased in a nonmetallic covering.
+-</P>
+-<P>(e) Exemptions recognized in the industry and not to be considered in any assay for quality of a platinum industry product include springs, winding bars, sleeves, crown cores, mechanical joint pins, screws, rivets, dust bands, detachable movement rims, hat-pin stems, and bracelet and necklace snap tongues. In addition, the following exemptions are recognized for products marked in accordance with section 23.8(b)(5) of these Guides (i.e., products that are less than 500 parts per thousand platinum): pin tongues, joints, catches, lapel button backs and the posts to which they are attached, scarf-pin stems, hat pin sockets, shirt-stud backs, vest-button backs, and ear-screw backs, provided such parts are made of the same quality platinum as is used in the balance of the article.
+-
+-
+-</P>
+-</DIV9>
+-
+ </DIV5>
+ 
+ 

--- a/16/001-remove-old-dup-sections-part-23/meta.yml
+++ b/16/001-remove-old-dup-sections-part-23/meta.yml
@@ -1,0 +1,8 @@
+description: 16 CFR 23 was replaced with updated sections, however for a few title versions the old sections remained. This removes these older duplicate sections.
+tags: 'content'
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2018-08-18'
+    end_date: '2018-08-24'


### PR DESCRIPTION
This creates a patch to remove 16 CFR 23 duplicate sections that are left over when all of Part 23 sections were revised. These older sections were present for three title_versions.

This closes #76 