### PR TITLE
SIMPLE: Set Title 34 patch end date to last day of mangled/missing date

### DIFF
--- a/34/002-fix-missing-amendment-date/meta.yml
+++ b/34/002-fix-missing-amendment-date/meta.yml
@@ -5,4 +5,4 @@ status: 'needs-review'
 patches:
   '001':
     start_date: '2018-10-19'
-    end_date: '2100-01-01'
+    end_date: '2018-10-25'


### PR DESCRIPTION
This sets the patch end date for this mangled amendment date

```shell

root@ecfr-versioner-blue-ecfr-versioner-1:/home/app# grep -r "<AMDDATE>, 2018" d
ata/titles/source/xml/34/2018/                                                  

data/titles/source/xml/34/2018/10/2018-10-25.xml:<AMDDATE>, 2018                
data/titles/source/xml/34/2018/10/2018-10-23.xml:<AMDDATE>, 2018                
data/titles/source/xml/34/2018/10/2018-10-19.xml:<AMDDATE>, 2018


root@ecfr-versioner-blue-ecfr-versioner-1:/home/app# grep -r "<AMDDATE>, 2018" d
ata/titles/source/xml/34/2019/                                                  
> 
# none
```
