### PR TITLE
48 CFR 552.238-80 Re-insert removed reserved tag #82

### DIFF
--- a/48/004-insert-removed-reserved-section-552.238-80/001.patch
+++ b/48/004-insert-removed-reserved-section-552.238-80/001.patch
@@ -1,0 +1,15 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/48/2019/04/2019-04-30T12:30:07-0400.xml	2019-05-13 12:41:22.000000000 -0700
++++ tmp/title_version_48_2019-04-30T12:30:07-0400_preprocessed.xml	2019-05-13 12:44:56.000000000 -0700
+@@ -153545,8 +153545,10 @@
+ </CITA>
+ </DIV8>
+ 
+-
+-
++<DIV8 N="552.238-80" TYPE="SECTION">
++<HEAD>552.238-80   [Reserved]</HEAD>
++<XREF ID="20190423" REFID="37">Link to an amendment published at 84 FR 17043, Apr. 23, 2019.</XREF>
++</DIV8> 
+ 
+ 
+ <DIV8 N="552.238-81" TYPE="SECTION">

--- a/48/004-insert-removed-reserved-section-552.238-80/meta.yml
+++ b/48/004-insert-removed-reserved-section-552.238-80/meta.yml
@@ -5,4 +5,4 @@ status: 'needs-review'
 patches:
   '001':
     start_date: '2019-04-30'
-    end_date: '2100-01-01'
+    end_date: '2019-05-23'

--- a/48/004-insert-removed-reserved-section-552.238-80/meta.yml
+++ b/48/004-insert-removed-reserved-section-552.238-80/meta.yml
@@ -1,0 +1,8 @@
+description: Section 852.238-80 is being removed because the section was modified to include a cross reference node that links a change that will transform the node from reserved to containing content May 23, 2019. While the cross reference node was inserted, a trailing XXX was added, which is making our processing infer that that the node is being removed. The node should stay as a reserved node until the change on May 23.
+tags: 'content-error'
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2019-04-30'
+    end_date: '2100-01-01'


### PR DESCRIPTION
This creates a patch to restore `48 CFR 552.238-80` which is appearing as an unnecessary cross ref tag in our preprocessed XML and being removed. This restores the section as a reserved tag.

On about May 23, 2019 we should be able to set an end date on this patch once the node is updated to be an active node with content.

This closes #82 