### PR TITLE
Restore missing 15 CFR 2004 identifier #54

### DIFF
--- a/15/004-add-missing-part-2004-id/001.patch
+++ b/15/004-add-missing-part-2004-id/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/15/2017/01/2017-01-03.xml	2019-05-17 16:54:28.000000000 -0700
++++ tmp/title_version_15_2017-01-03T00:00:00-0500_preprocessed.xml	2019-05-17 16:55:16.000000000 -0700
+@@ -102080,7 +102080,7 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="" TYPE="PART">
++<DIV5 N="2004" TYPE="PART">
+ <HEAD>DISCLOSURE OF RECORDS AND INFORMATION
+ </HEAD>
+ <SOURCE>

--- a/15/004-add-missing-part-2004-id/meta.yml
+++ b/15/004-add-missing-part-2004-id/meta.yml
@@ -1,0 +1,8 @@
+description: 'Title 15 Part 2004 was missing an identifier in both the head and identifier for most of 2017. This restores the identifier but does not update the visible description/head tag.'
+tags: ['content-error']
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2015-01-01'
+    end_date: '2017-09-28'

--- a/15/004-add-missing-part-2004-id/meta.yml
+++ b/15/004-add-missing-part-2004-id/meta.yml
@@ -1,6 +1,6 @@
 description: 'Title 15 Part 2004 was missing an identifier in both the head and identifier for most of 2017. This restores the identifier but does not update the visible description/head tag.'
 tags: ['content-error']
-status: 'needs-review'
+status: 'approved'
 
 patches:
   '001':


### PR DESCRIPTION
This adds an identifier for 15 CFR 2004. It is missing an id from content epoch through 2017-09-28. This closes #54 