### PR TITLE
Remove duplicate 48 cfr 852.236 72

### DIFF
--- a/48/005-remove-duplicate-section-852.236-72/001.patch
+++ b/48/005-remove-duplicate-section-852.236-72/001.patch
@@ -1,0 +1,34 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/48/2019/04/2019-04-22T20:30:11-0400.xml	2019-05-21 14:48:07.000000000 -0700
++++ tmp/title_version_48_2019-04-22T20:30:11-0400_preprocessed.xml	2019-05-21 15:01:02.000000000 -0700
+@@ -180058,31 +180058,6 @@
+ </DIV8>
+ 
+ 
+-<DIV8 N="852.236-72" TYPE="SECTION">
+-<HEAD>852.236-72   Performance of work by the contractor.</HEAD>
+-<P>As prescribed in 836.501, insert the following clause:
+-</P>
+-<EXTRACT>
+-<HD1>Performance of Work by the Contractor (Apr 2019)
+-</HD1>
+-<P>(a) In accordance with FAR 52.236-1, the contract work accomplished on the site by laborers, mechanics, and foreman/superintendent on the Contractor's payroll and under their direct supervision shall be used in establishing the percent of work to be performed by the Contractor. Cost of material and equipment installed by such labor may be included. The work by the Contractor's executive, administrative and clerical forces shall be excluded in establishing compliance with the requirements of this clause.
+-</P>
+-<P>(b) The Contractor shall submit, simultaneously with the schedule of costs required by the Payments under Fixed-Price Construction Contracts clause of the contract, a statement designating the portions of contract work to be performed with the Contractor's own forces. The approved schedule of costs will be used in determining the value of a work activity/event, or portions thereof, of the work for the purpose of this article.
+-</P>
+-<P>(c) Changes to established activity/event identifiers or responsibility codes for Contractor activities shall not be made without approval from the Contracting Officer.
+-</P>
+-<P>(d) In the event the Contractor fails to comply with FAR 52.236-1, Performance of Work by the Contractor, the Contracting Officer will withhold retention in the amount of 15% of the value of any work activity/element being invoiced that was not authorized by the Contracting Officer to be performed by someone other than the prime Contractor's own workforce.</P></EXTRACT>
+-<FP>(End of clause)
+-</FP>
+-<P><I>Alternate I</I> <I>(APR 2019).</I> For requirements which include a Network Analysis System (NAS), substitute the following paragraph (b) for paragraph (b) of the basic clause:
+-</P>
+-<P>(b) The Contractor shall submit, simultaneously with the cost per activity of the construction schedule required by Section 01310 or 01311, NETWORK ANALYSIS SYSTEM, a responsibility code for all activities of the network for which the Contractor's forces will perform the work. The cost of these activities will be used in determining the portions of the total contract work to be executed by the Contractor's forces for the purpose of this article.
+-</P>
+-<CITA TYPE="N">[84 FR 9974, Mar. 19, 2019]
+-
+-
+-</CITA>
+-</DIV8>
+ 
+ 
+ <DIV8 N="852.236-73 - 852.236-78" TYPE="SECTION">

--- a/48/005-remove-duplicate-section-852.236-72/meta.yml
+++ b/48/005-remove-duplicate-section-852.236-72/meta.yml
@@ -1,0 +1,8 @@
+description: 'This removes a duplicate section 48 CFR 852.236-72.'
+tags: 'content-error'
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2019-04-22'
+    end_date: '2100-01-01'


### PR DESCRIPTION
This removes a duplicate Title 48 Section 852.236-72 tag.

- [ ] This is branched off another Title 48 patch, so this should me merged in AFTER https://github.com/criticaljuncture/ecfr-xml-corrections/pull/83

This closes #88 