### PR TITLE
Remove 'ecfrcor' in amendment date #93

### DIFF
--- a/21/002-remove-ecfrcor-from-amendment-date/001.patch
+++ b/21/002-remove-ecfrcor-from-amendment-date/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/21/2019/04/2019-04-10T19:00:07-0500.xml	2019-06-05 11:37:13.000000000 -0700
++++ tmp/title_version_21_2019-04-10T20:00:07-0400_preprocessed.xml	2019-06-05 11:38:38.000000000 -0700
+@@ -115772,7 +115772,7 @@
+ 
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>Apr. 9, 2019 (ecfrcor)
++<AMDDATE>Apr. 9, 2019
+ </AMDDATE>
+ 
+ <DIV1 N="6" TYPE="TITLE">

--- a/21/002-remove-ecfrcor-from-amendment-date/meta.yml
+++ b/21/002-remove-ecfrcor-from-amendment-date/meta.yml
@@ -1,0 +1,8 @@
+description: 'Amendment date included "(ecfrcor)" because update was corrections, but text is unnecessary.'
+tags: 'structural'
+status: 'needs-approved'
+
+patches:
+  '001':
+    start_date: '2019-04-09 20:00:06 -0400'
+    end_date: '2100-01-01'


### PR DESCRIPTION
This removes a "(ecfrcor)" that was accidentally added to an amendment date during some correction fixing. This message isn't needed and should be removed.

This closes #93 