### PR TITLE
Add: Patch missing month in Title 21 #97

### DIFF
--- a/21/002-remove-ecfrcor-from-amendment-date/meta.yml
+++ b/21/002-remove-ecfrcor-from-amendment-date/meta.yml
@@ -4,5 +4,5 @@ status: 'needs-approved'
 
 patches:
   '001':
-    start_date: '2019-04-09 20:00:06 -0400'
+    start_date: '2019-04-09'
     end_date: '2100-01-01'

--- a/21/003-amddate-missing-month/001.patch
+++ b/21/003-amddate-missing-month/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/21/2019/05/2019-05-02T20:00:07-0400.xml	2019-06-17 11:56:59.000000000 -0700
++++ tmp/title_version_21_2019-05-02T20:00:07-0400_preprocessed.xml	2019-06-17 11:57:45.000000000 -0700
+@@ -159331,7 +159331,7 @@
+ 
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE> 1, 2019
++<AMDDATE>May 1, 2019
+ </AMDDATE>
+ 
+ <DIV1 N="8" TYPE="TITLE">

--- a/21/003-amddate-missing-month/meta.yml
+++ b/21/003-amddate-missing-month/meta.yml
@@ -4,5 +4,5 @@ status: 'needs-approved'
 
 patches:
   '001':
-    start_date: '2019-05-02T20:00:07-0400'
-    end_date: '2019-05-09T20:00:07-0400'
+    start_date: '2019-05-02'
+    end_date: '2019-05-09'

--- a/21/003-amddate-missing-month/meta.yml
+++ b/21/003-amddate-missing-month/meta.yml
@@ -1,0 +1,8 @@
+description: 'Amendment date was missing month (May). This adds "May" for three title versions.'
+tags: 'structural'
+status: 'needs-approved'
+
+patches:
+  '001':
+    start_date: '2019-05-02T20:00:07-0400'
+    end_date: '2019-05-09T20:00:07-0400'


### PR DESCRIPTION
This patches three title versions whose xml include amendment dates with a missing month (May).

This closes #97 