### PR TITLE
Add: Patch wrong Title 3 amendment date

### DIFF
--- a/03/001-patch-incorrect-date/001.patch
+++ b/03/001-patch-incorrect-date/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/03/2018/10/2018-10-17.xml	2019-07-03 09:53:57.000000000 -0700
++++ tmp/title_version_3_2018-10-17T01:00:00-0400_preprocessed.xml	2019-07-03 09:56:28.000000000 -0700
+@@ -34,7 +34,7 @@
+ <TEXT>
+ <BODY>
+ <ECFRBRWS>
+-<AMDDATE>January 4, 2011
++<AMDDATE>March 17, 2015
+ </AMDDATE>
+ 
+ <DIV1 N="1" TYPE="TITLE">

--- a/03/001-patch-incorrect-date/meta.yml
+++ b/03/001-patch-incorrect-date/meta.yml
@@ -1,0 +1,8 @@
+description: The amendment date for Title 3 was accidentally moved forward while some corrections/cleanup were being made. This reverts the amendment date.
+tags: 'amendment date'
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2018-10-17'
+    end_date: '2019-02-09'


### PR DESCRIPTION
This reverts an amendment date that was incorrectly changed during some ecfr cleanup. This closes #94 