### PR TITLE
Set end date for duplicate Chapter CI removal

### DIFF
--- a/05/001-fix-duplicate-chapter-CI/meta.yml
+++ b/05/001-fix-duplicate-chapter-CI/meta.yml
@@ -5,4 +5,4 @@ status: 'needs-approval'
 patches:
   '001':
     start_date: '2018-11-03'
-    end_date: '2100-01-01'
+    end_date: '2019-05-22 00:00:06 -0400'


### PR DESCRIPTION
The second title_version for Title 5 on 5-22-2019  (received_on: 2019-05-22 23:30:03) removes a duplicate CI tag from the xml so a patch we were applying is no longer necessary. This sets an end date for this patch. 