### PR TITLE
Update Title 49 patches to solve issues with preprocessor re-ordering

### DIFF
--- a/49/003-change-pseudo-Parts-to-Text/001.patch
+++ b/49/003-change-pseudo-Parts-to-Text/001.patch
@@ -1,5 +1,5 @@
---- /home/app/data/titles/preprocessed/xml/49/2017/01/2017-01-03.xml	2018-12-10 17:29:31.463558367 -0500
-+++ tmp/title_version_48_preprocessed.xml	2018-12-10 17:46:37.545308490 -0500
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/49/2017/01/2017-01-03.xml	2019-07-05 12:54:32.000000000 -0700
++++ tmp/title_version_49_2017-01-03T00:00:00-0500_preprocessed.xml	2019-07-05 13:06:52.000000000 -0700
 @@ -275487,12 +275487,10 @@
  
  </HEAD>
@@ -174,14 +174,13 @@
  </DIV5>
  
  
--<DIV5 N="1240-1259" TYPE="PART">
+-<DIV5 N="1240" TYPE="PART">
 -<HEAD>PARTS 1240-1259 - REPORTS
 -
--
+ 
 -</HEAD>
 +<TEXT>
-+  <HED1>PARTS 1240-1259 - REPORTS
-+  </HED1>
++  <HED1>PARTS 1240-1259 - REPORTS</HED1>
  <NOTE>
  <HED>Note:</HED>
  <P>The report forms prescribed by parts 1240-1259 are available upon request from the Office of Economics, Surface Transportation Board, Washington, DC.</P></NOTE>
@@ -190,16 +189,15 @@
  
  
  <DIV5 N="1241" TYPE="PART">
-@@ -301941,13 +301919,13 @@
+@@ -301941,13 +301919,12 @@
  </DIV5>
  
  
--<DIV5 N="1260-1269" TYPE="PART">
+-<DIV5 N="1260" TYPE="PART">
 -<HEAD>PARTS 1260-1269 - VALUATION
 -</HEAD>
 +<TEXT>
-+<HED1>PARTS 1260-1269 - VALUATION
-+</HED1>
++  <HED1>PARTS 1260-1269 - VALUATION</HED1>
  <NOTE>
  <HED>Note:</HED>
  <P>The report forms prescribed by parts 1260-1269 are available upon request from the Office of Economics, Environmental Analysis, and Administration, Surface Transportation Board, Washington, DC 20423-0001.</P></NOTE>
@@ -208,7 +206,7 @@
  
  
  <DIV5 N="1260-1261" TYPE="PART">
-@@ -301958,12 +301936,10 @@
+@@ -301958,12 +301935,10 @@
  </DIV5>
  
  

--- a/49/003-change-pseudo-Parts-to-Text/002.patch
+++ b/49/003-change-pseudo-Parts-to-Text/002.patch
@@ -1,5 +1,5 @@
---- /home/app/data/titles/preprocessed/xml/49/2018/04/2018-04-23.xml	2018-12-10 18:17:18.459593757 -0500
-+++ tmp/title_version_6437_preprocessed.xml	2018-12-10 18:25:04.516253432 -0500
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/49/2018/04/2018-04-23.xml	2019-07-08 14:39:26.000000000 -0700
++++ tmp/title_version_49_2018-04-23T01:00:00-0400_preprocessed.xml	2019-07-08 14:42:51.000000000 -0700
 @@ -285435,12 +285435,10 @@
  
  </HEAD>
@@ -174,14 +174,13 @@
  </DIV5>
  
  
--<DIV5 N="1240-1259" TYPE="PART">
+-<DIV5 N="1240" TYPE="PART">
 -<HEAD>PARTS 1240-1259 - REPORTS
 -
--
+ 
 -</HEAD>
 +<TEXT>
-+  <HED1>PARTS 1240-1259 - REPORTS
-+  </HED1>
++  <HED1>PARTS 1240-1259 - REPORTS</HED1>
  <NOTE>
  <HED>Note:</HED>
  <P>The report forms prescribed by parts 1240-1259 are available upon request from the Office of Economics, Surface Transportation Board, Washington, DC.</P></NOTE>
@@ -190,16 +189,16 @@
  
  
  <DIV5 N="1241" TYPE="PART">
-@@ -312361,25 +312339,23 @@
+@@ -312360,26 +312338,22 @@
+ 
  </DIV5>
  
- 
--<DIV5 N="1260-1269" TYPE="PART">
+-
+-<DIV5 N="1260" TYPE="PART">
 -<HEAD>PARTS 1260-1269 - VALUATION
 -</HEAD>
 +<TEXT>
-+<HED1>PARTS 1260-1269 - VALUATION
-+</HED1>
++  <HED1>PARTS 1260-1269 - VALUATION</HED1>
  <XREF ID="20180419">Link to an amendment published at 83 FR 17300, Apr. 19, 2018.</XREF>
  <NOTE>
  <HED>Note:</HED>

--- a/49/003-change-pseudo-Parts-to-Text/003.patch
+++ b/49/003-change-pseudo-Parts-to-Text/003.patch
@@ -1,5 +1,5 @@
---- /home/app/data/titles/preprocessed/xml/49/2018/05/2018-05-23.xml	2018-12-10 19:14:09.832267746 -0500
-+++ tmp/title_version_6609_preprocessed.xml	2018-12-10 19:15:35.438825149 -0500
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/49/2018/05/2018-05-23.xml	2019-07-08 14:53:15.000000000 -0700
++++ tmp/title_version_49_2018-05-23T01:00:00-0400_preprocessed.xml	2019-07-08 14:58:26.000000000 -0700
 @@ -285508,12 +285508,10 @@
  
  </HEAD>
@@ -174,14 +174,13 @@
  </DIV5>
  
  
--<DIV5 N="1240-1259" TYPE="PART">
+-<DIV5 N="1240" TYPE="PART">
 -<HEAD>PARTS 1240-1259 - REPORTS
 -
--
+ 
 -</HEAD>
 +<TEXT>
-+  <HED1>PARTS 1240-1259 - REPORTS
-+  </HED1>
++  <HED1>PARTS 1240-1259 - REPORTS</HED1>
  <NOTE>
  <HED>Note:</HED>
  <P>The report forms prescribed by parts 1240-1259 are available upon request from the Office of Economics, Surface Transportation Board, Washington, DC.</P></NOTE>
@@ -190,3 +189,21 @@
  
  
  <DIV5 N="1241" TYPE="PART">
+@@ -312340,13 +312318,10 @@
+ </DIV5>
+ 
+ 
+-<DIV5 N="1280-1299" TYPE="PART">
+-<HEAD>PARTS 1280-1299 - CLASSIFICATION AND DECLASSIFICATION OF NATIONAL SECURITY INFORMATION AND MATERIAL
+-
+-
+-</HEAD>
+-</DIV5>
+-
++<TEXT>
++<HED1>PARTS 1280-1299 - CLASSIFICATION AND DECLASSIFICATION OF NATIONAL SECURITY INFORMATION AND MATERIAL
++</HED1>
++</TEXT>
+ 
+ <DIV5 N="1280" TYPE="PART">
+ <HEAD>PART 1280 - HANDLING OF NATIONAL SECURITY INFORMATION AND CLASSIFIED MATERIAL


### PR DESCRIPTION
This regenerates Title 49 patches for numerous part nodes that are more like labels (no children). Instead we modify them to be TEXT nodes. This updates the final patch to have the same transformation as the others on the `PARTS 1280-1299` node.

This closes #81 