### PR TITLE
Add: Patch for generated id on 33 CFR special note #107

### DIFF
--- a/33/002-add-ecfr-identifier-to-special-note/001.patch
+++ b/33/002-add-ecfr-identifier-to-special-note/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/33/2017/01/2017-01-03.xml	2019-07-12 11:24:40.000000000 -0700
++++ tmp/title_version_33_2017-01-03T00:00:00-0500_preprocessed.xml	2019-07-12 11:27:49.000000000 -0700
+@@ -11034,7 +11034,7 @@
+ 
+ </HEAD>
+ 
+-<DIV5 N="" TYPE="PART">
++<DIV5 N="ECFR1a48483536b7c15" TYPE="PART">
+ <HEAD>Special Note - Application of the 72 COLREGS to territories and possessions.
+ </HEAD>
+ <EXTRACT>

--- a/33/002-add-ecfr-identifier-to-special-note/meta.yml
+++ b/33/002-add-ecfr-identifier-to-special-note/meta.yml
@@ -1,6 +1,6 @@
-description: Amendment date was incorrectly entered as Dec 24, 26. It should be Dec 26.
-tags: 'structural, transcription-error'
-status: 'approved'
+description: This adds a generated identifier for tracking a psuedo part node that is labled as a special note
+tags: 'transcription-error'
+status: 'needs-approval'
 
 patches:
   '001':

--- a/33/002-add-ecfr-identifier-to-special-note/meta.yml
+++ b/33/002-add-ecfr-identifier-to-special-note/meta.yml
@@ -1,0 +1,8 @@
+description: Amendment date was incorrectly entered as Dec 24, 26. It should be Dec 26.
+tags: 'structural, transcription-error'
+status: 'approved'
+
+patches:
+  '001':
+    start_date: '2015-01-01'
+    end_date: '2099-09-09'


### PR DESCRIPTION
This creates a new patch to apply a generated id to a special note that persists throughout all title versions of Title 33

This closes #107 