### PR TITLE
remove double section head tag in 50 CFR 648.65 #111

### DIFF
--- a/50/006-remove-double-section-head-tag/001.patch
+++ b/50/006-remove-double-section-head-tag/001.patch
@@ -1,0 +1,10 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/50/2018/04/2018-04-23.xml	2019-07-18 16:51:05.000000000 -0700
++++ tmp/title_version_50_2018-04-23T01:00:00-0400_preprocessed.xml	2019-07-18 16:53:02.000000000 -0700
+@@ -203383,7 +203383,6 @@
+ 
+ 
+ <DIV8 N="§ 648.65" TYPE="SECTION">
+-<HEAD>§ 648.65   </HEAD>
+ <HEAD>§ 648.65   [Reserved]</HEAD>
+ </DIV8>
+ 

--- a/50/006-remove-double-section-head-tag/meta.yml
+++ b/50/006-remove-double-section-head-tag/meta.yml
@@ -1,0 +1,8 @@
+description: When 50 CFR  648.65 was turned into a reserved node an additional head tag was inserted. This removes this additional head tag in favor of the reserved tag because the node is empty. 
+tags: ['content']
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2018-04-23'
+    end_date: '2099-09-09'


### PR DESCRIPTION
This creates a patch to remove a second head tag that was accidentally inserted when switching a tag from with content to become an empty reserved section. This closes #111 