### PR TITLE
Add end_date to Title 21 mangled ecfrcor amendment date

### DIFF
--- a/21/002-remove-ecfrcor-from-amendment-date/meta.yml
+++ b/21/002-remove-ecfrcor-from-amendment-date/meta.yml
@@ -5,4 +5,4 @@ status: 'needs-approved'
 patches:
   '001':
     start_date: '2019-04-10'
-    end_date: '2100-01-01'
+    end_date: '2019-07-05'


### PR DESCRIPTION
The bad amendment date with ecfrcor in it seems to be fixed on July 12. This sets an end date to the last title_version that requires this fix.

```shell
root@ecfr-versioner-green-ecfr-versioner-1:/home/app# grep "<AMDDATE>" -r data/titles/source/xml/21/2019/07/ | sort
data/titles/source/xml/21/2019/07/2019-07-05T20:30:06-0400.xml:<AMDDATE>Apr. 2, 2019
data/titles/source/xml/21/2019/07/2019-07-05T20:30:06-0400.xml:<AMDDATE>Apr. 9, 2019 (ecfrcor)
data/titles/source/xml/21/2019/07/2019-07-05T20:30:06-0400.xml:<AMDDATE>April 1, 2019
data/titles/source/xml/21/2019/07/2019-07-05T20:30:06-0400.xml:<AMDDATE>July 2, 2019
data/titles/source/xml/21/2019/07/2019-07-05T20:30:06-0400.xml:<AMDDATE>July 2, 2019
data/titles/source/xml/21/2019/07/2019-07-05T20:30:06-0400.xml:<AMDDATE>June 14, 2019
data/titles/source/xml/21/2019/07/2019-07-05T20:30:06-0400.xml:<AMDDATE>June 17, 2019
data/titles/source/xml/21/2019/07/2019-07-05T20:30:06-0400.xml:<AMDDATE>May 2, 2019
data/titles/source/xml/21/2019/07/2019-07-05T20:30:06-0400.xml:<AMDDATE>Oct. 9, 2017


data/titles/source/xml/21/2019/07/2019-07-12T20:30:06-0400.xml:<AMDDATE>Apr. 2, 2019
data/titles/source/xml/21/2019/07/2019-07-12T20:30:06-0400.xml:<AMDDATE>April 1, 2019
data/titles/source/xml/21/2019/07/2019-07-12T20:30:06-0400.xml:<AMDDATE>July 11, 2019
data/titles/source/xml/21/2019/07/2019-07-12T20:30:06-0400.xml:<AMDDATE>July 2, 2019
data/titles/source/xml/21/2019/07/2019-07-12T20:30:06-0400.xml:<AMDDATE>July 2, 2019
data/titles/source/xml/21/2019/07/2019-07-12T20:30:06-0400.xml:<AMDDATE>June 14, 2019
data/titles/source/xml/21/2019/07/2019-07-12T20:30:06-0400.xml:<AMDDATE>June 17, 2019
data/titles/source/xml/21/2019/07/2019-07-12T20:30:06-0400.xml:<AMDDATE>May 2, 2019
data/titles/source/xml/21/2019/07/2019-07-12T20:30:06-0400.xml:<AMDDATE>Oct. 9, 2017
```
