### PR TITLE
Add: Patch 50 CFR 17.95 ammendment date to be correct year #115

### DIFF
--- a/50/006-fix-amendment-date-year/001.patch
+++ b/50/006-fix-amendment-date-year/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/50/2019/05/2019-05-09T21:00:06-0400.xml	2019-07-25 11:35:55.000000000 -0700
++++ tmp/title_version_50_2019-05-09T21:00:06-0400_preprocessed.xml	2019-07-25 11:38:42.000000000 -0700
+@@ -42431,7 +42431,7 @@
+ 
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>May 7, 2018
++<AMDDATE>May 7, 2019
+ </AMDDATE>
+ 
+ <DIV1 N="4" TYPE="TITLE">

--- a/50/006-fix-amendment-date-year/meta.yml
+++ b/50/006-fix-amendment-date-year/meta.yml
@@ -1,0 +1,8 @@
+description: An amendment date was updated but incorrectly used 2018 instead of 2019 resulting in a reverse amendment date. This updates this to be 2019.
+tags: ['structural']
+status: 'needs-review'
+
+patches:
+  '001':
+    start_date: '2019-05-09'
+    end_date: '2019-05-21'


### PR DESCRIPTION
This corrects `<AMDDATE>May 7, 2018` to be `<AMDDATE>May 7, 2019`. 
When this amendment date was updated it was set incorrectly resulting in a reverse amendment date. 

This closes #115 

<img width="870" alt="Screen Shot 2019-07-25 at 11 04 43 AM" src="https://user-images.githubusercontent.com/3782822/61900958-84bfb700-aed3-11e9-80b3-f12c09767d26.png">
