### PR TITLE
Patch Title 18 incorrect year on amendment date #114

### DIFF
--- a/18/001-fix-amendment-date-year-volume-2/001.patch
+++ b/18/001-fix-amendment-date-year-volume-2/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/18/2019/06/2019-06-12T20:00:05-0400.xml	2019-07-25 12:06:31.000000000 -0700
++++ tmp/title_version_18_2019-06-12T20:00:05-0400_preprocessed.xml	2019-07-25 12:07:43.000000000 -0700
+@@ -65057,7 +65057,7 @@
+ 
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>June 11, 2018 
++<AMDDATE>June 11, 2019
+ </AMDDATE>
+ 
+ <DIV1 N="2" TYPE="TITLE">

--- a/18/001-fix-amendment-date-year-volume-2/meta.yml
+++ b/18/001-fix-amendment-date-year-volume-2/meta.yml
@@ -1,0 +1,8 @@
+description: Amendment date month/day were changed but year was accidentally not incremented.
+tags: 'structural'
+status: 'needs-approved'
+
+patches:
+  '001':
+    start_date: '2019-06-12'
+    end_date: '2019-06-28'


### PR DESCRIPTION
This fixes an incorrect year on an updated/reversed amendment date. It should be 2019 not 2018.

This closes #114 