### PR TITLE
Add: Patch Title 26 Volume 5, 6 amddates

### DIFF
--- a/26/002-patch-Title-26-amddates-2019/001.patch
+++ b/26/002-patch-Title-26-amddates-2019/001.patch
@@ -1,0 +1,20 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/26/2019/03/2019-03-19T22:00:11-0400.xml	2019-08-05 10:05:53.000000000 -0700
++++ tmp/title_version_26_2019-03-19T22:00:11-0400_preprocessed.xml	2019-08-05 10:21:37.000000000 -0700
+@@ -79034,7 +79034,7 @@
+
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>Mar. 14, 2018
++<AMDDATE>Mar. 14, 2019
+ </AMDDATE>
+
+ <DIV1 N="5" TYPE="TITLE">
+@@ -100290,7 +100290,7 @@
+
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>Mar. 14, 2018
++<AMDDATE>Mar. 14, 2019
+ </AMDDATE>
+
+ <DIV1 N="6" TYPE="TITLE">

--- a/26/002-patch-Title-26-amddates-2019/002.patch
+++ b/26/002-patch-Title-26-amddates-2019/002.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/26/2019/04/2019-04-08T22:30:09-0400.xml	2019-08-05 10:43:03.000000000 -0700
++++ tmp/title_version_26_2019-04-08T22:30:09-0400_preprocessed.xml	2019-08-05 10:51:08.000000000 -0700
+@@ -100102,7 +100102,7 @@
+
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>Mar. 14, 2018
++<AMDDATE>Mar. 14, 2019
+ </AMDDATE>
+
+ <DIV1 N="6" TYPE="TITLE">

--- a/26/002-patch-Title-26-amddates-2019/meta.yml
+++ b/26/002-patch-Title-26-amddates-2019/meta.yml
@@ -1,0 +1,14 @@
+description: "Update Title 26 volumes 5 and 6 amddates to be 2019 instead of incorrect 2018. Patch 001 applies to both, Patch 002 is only to volume 6."
+tags: 'amendment-date'
+status: 'needs-approval'
+issue_number: '118'
+fr_doc:
+reference:
+
+patches:
+  '001':
+    start_date: '2019-03-19'
+    end_date: '2019-04-05'
+  '002':
+    start_date: '2019-04-08'
+    end_date: '2019-07-29T12:00:13-0400'


### PR DESCRIPTION
This creates two patches for volume 5, 6 amddates to be 2019 instead of 2018 for Title 26.

this closes #118 