### PR TITLE
Patch Title 24 amddate to be 2019 

### DIFF
--- a/24/002-patch-amddate-2019/001.patch
+++ b/24/002-patch-amddate-2019/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/24/2019/03/2019-03-19T21:30:05-0400.xml	2019-08-05 13:48:35.000000000 -0700
++++ tmp/title_version_24_2019-03-19T21:30:05-0400_preprocessed.xml	2019-08-05 13:58:11.000000000 -0700
+@@ -34231,7 +34231,7 @@
+
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>Mar. 14, 2018
++<AMDDATE>Mar. 14, 2019
+ </AMDDATE>
+
+ <DIV1 N="2" TYPE="TITLE">

--- a/24/002-patch-amddate-2019/meta.yml
+++ b/24/002-patch-amddate-2019/meta.yml
@@ -1,0 +1,11 @@
+description: 'Patch Title 24 volume 2 amddate to be 2019 instead of 2018.'
+tags: 'amendment-date'
+status: 'needs-approval'
+issue_number: '125'
+fr_doc:
+reference:
+
+patches:
+  '001':
+    start_date: "2019-03-19"
+    end_date: "2099-09-09"


### PR DESCRIPTION
Create a patch for Title 24 to fix an incorrect amddate year from 2018 to 2019
This closes #125