### PR TITLE
Update: Close out Title 24 amddate patch

### DIFF
--- a/24/002-patch-amddate-2019/meta.yml
+++ b/24/002-patch-amddate-2019/meta.yml
@@ -7,5 +7,5 @@ reference:
 
 patches:
   '001':
-    start_date: "2019-03-19"
-    end_date: "2099-09-09"
+    start_date: '2019-03-19'
+    end_date: '2019-08-16 00:13:18'


### PR DESCRIPTION
This closes out a patch to an amddate that is no longer required on most current xml because volume date changes to `Aug. 15, 2019`.