### PR TITLE
Add: Patch for malformed amendment date in Title 14 2019 #150

### DIFF
--- a/14/003-fix-malformed-amendment-date-2019/001.patch
+++ b/14/003-fix-malformed-amendment-date-2019/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/14/2019/08/2019-08-20T20:00:09-0400.xml	2019-08-21 14:03:25.000000000 -0700
++++ tmp/title_version_14_2019-08-20T20:00:09-0400_preprocessed.xml	2019-08-21 14:03:51.000000000 -0700
+@@ -50591,7 +50591,7 @@
+ 
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>Aug. 1963.14, 2019
++<AMDDATE>Aug. 19, 2019
+ </AMDDATE>
+ 
+ <DIV1 N="2" TYPE="TITLE">

--- a/14/003-fix-malformed-amendment-date-2019/meta.yml
+++ b/14/003-fix-malformed-amendment-date-2019/meta.yml
@@ -1,0 +1,11 @@
+description: 'Fix malformed date in Volume 2 of Title 14'
+tags: 'amendment-date'
+status: 'needs-approval'
+issue_number: '150'
+fr_doc: 'https://www.federalregister.gov/documents/2019/08/19/2019-17695/special-conditions-mitsubishi-aircraft-corporation-model-mrj-200-airplane-airplane-electronic-system'
+reference:
+
+patches:
+  '001':
+    start_date: '2019-08-20'
+    end_date: '2099-09-09'


### PR DESCRIPTION
Patch `Aug. 1963.14, 2019` to `Aug. 19, 2019`.

```ruby
Date.parse 'Aug. 1963.14, 2019'
=> Wed, 14 Aug 1963
```
👎 

FR Doc: https://www.federalregister.gov/documents/2019/08/19/2019-17695/special-conditions-mitsubishi-aircraft-corporation-model-mrj-200-airplane-airplane-electronic-system



This closes #150 