### PR TITLE
Patch 2018 reverse amddates

### DIFF
--- a/21/007-patch-2018-amddate/001.patch
+++ b/21/007-patch-2018-amddate/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/21/2018/01/2018-01-31.xml	2019-10-23 10:53:39.000000000 -0700
++++ tmp/title_version_21_2018-01-31T00:00:00-0500_preprocessed.xml	2019-10-23 10:54:08.000000000 -0700
+@@ -34,7 +34,7 @@
+ <TEXT>
+ <BODY>
+ <ECFRBRWS>
+-<AMDDATE>Jan. 29, 2017
++<AMDDATE>Jan. 29, 2018
+ </AMDDATE>
+
+ <DIV1 N="1" TYPE="TITLE">

--- a/21/007-patch-2018-amddate/meta.yml
+++ b/21/007-patch-2018-amddate/meta.yml
@@ -1,0 +1,10 @@
+description: 'This patches Title 21 Volume 1 amddate incorrect year from 2017 to 2018.'
+tags: 'amendment-date'
+status: 'needs-approval'
+issue_number: '153'
+reference:
+
+patches:
+  '001':
+    start_date: '2018-01-31'
+    end_date: '2018-03-28'

--- a/21/008-patch-2018-amddate/001.patch
+++ b/21/008-patch-2018-amddate/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/21/2018/10/2018-10-19.xml	2019-10-24 16:22:28.000000000 -0700
++++ tmp/title_version_21_2018-10-19T01:00:00-0400_preprocessed.xml	2019-10-24 16:30:27.000000000 -0700
+@@ -158612,7 +158612,7 @@
+
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>June 17, 2018
++<AMDDATE>Oct. 17, 2018
+ </AMDDATE>
+
+ <DIV1 N="8" TYPE="TITLE">

--- a/21/008-patch-2018-amddate/meta.yml
+++ b/21/008-patch-2018-amddate/meta.yml
@@ -1,0 +1,10 @@
+description: 'Change incorrect Title 21 Volume 8 amendment date from June 18 to October 18 2018.'
+tags: 'amendment-date'
+status: 'needs-approval'
+issue_number: 153
+reference: '2018-22694'
+
+patches:
+  '001':
+    start_date: '2018-10-19'
+    end_date: '2018-10-19'

--- a/24/003-patch-amddate-2018/001.patch
+++ b/24/003-patch-amddate-2018/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/24/2018/07/2018-07-06.xml	2019-10-23 09:54:08.000000000 -0700
++++ tmp/title_version_24_2018-07-06T01:00:00-0400_preprocessed.xml	2019-10-23 09:54:38.000000000 -0700
+@@ -34198,7 +34198,7 @@
+
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>July 3, 2017
++<AMDDATE>July 3, 2018
+ </AMDDATE>
+
+ <DIV1 N="2" TYPE="TITLE">

--- a/24/003-patch-amddate-2018/meta.yml
+++ b/24/003-patch-amddate-2018/meta.yml
@@ -1,0 +1,13 @@
+description: 'Patch Title 24 volume 2 amddate to be 2018 instead of 2017.'
+tags: 'amendment-date'
+status: 'needs-approval'
+issue_number: '153'
+fr_doc:
+reference:
+
+patches:
+  '001':
+    start_date: '2018-07-06'
+    # end_date: '2018-07-24'
+    end_date: '2099-07-24'
+

--- a/50/010-fix-volume-12-amddate-2018/001.patch
+++ b/50/010-fix-volume-12-amddate-2018/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/50/2018/02/2018-02-15.xml	2019-10-25 14:51:48.000000000 -0700
++++ tmp/title_version_50_2018-02-15T00:00:00-0500_preprocessed.xml	2019-10-25 14:52:39.000000000 -0700
+@@ -175964,7 +175964,7 @@
+
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>Jan. 13, 2018
++<AMDDATE>Feb. 13, 2018
+ </AMDDATE>
+
+ <DIV1 N="12" TYPE="TITLE">

--- a/50/010-fix-volume-12-amddate-2018/meta.yml
+++ b/50/010-fix-volume-12-amddate-2018/meta.yml
@@ -1,0 +1,11 @@
+description: Patch incorrect Title 50 amddate, volume 12 had a cross reference inserted. Month mistakenly went backward (January instead of February).
+tags: 'amendment-date'
+status: 'needs-approval'
+issue_number: 153
+fr_doc:
+reference:
+
+patches:
+  '001':
+    start_date: '2018-02-15'
+    end_date: '2018-02-28'


### PR DESCRIPTION
This fixes all of the remaining 2018 amendment date issues except for https://github.com/criticaljuncture/ecfr-xml-corrections/issues/158 

This closes #153 