### PR TITLE
Update: Close out patch to Title 21 Vol 6 future amddate

### DIFF
--- a/21/006-patch-amddate-vol-9/meta.yml
+++ b/21/006-patch-amddate-vol-9/meta.yml
@@ -7,4 +7,4 @@ reference:
 patches:
   '001':
     start_date: '2019-10-01 20:00:00'
-    end_date: '2099-09-09'
+    end_date: '2019-10-19'


### PR DESCRIPTION
This closes out a patch to a patch used to fix a future (2020) amddate in Title 21 - Volume 9.

This date has been corrected. 

<img width="761" alt="Screen Shot 2019-11-18 at 5 01 27 PM" src="https://user-images.githubusercontent.com/3782822/69107180-6bfc8380-0a25-11ea-9020-77da2598314e.png">
