### PR TITLE
Update: Close out missing Title 34 Vol 4 missing ammdate patch

### DIFF
--- a/34/003-add-missing-amddate/meta.yml
+++ b/34/003-add-missing-amddate/meta.yml
@@ -6,4 +6,4 @@ reference: 'https://criticaljuncture.basecamphq.com/projects/4648449-federal-reg
 patches:
   '001':
     start_date: '2019-09-25'
-    end_date: '2099-09-09'
+    end_date: '2019-11-25'


### PR DESCRIPTION
This closes out a patch that was fixing a malformed/blank amddate for Title 34 Vol 4. This missing amendment date changes to Nov 26, 2019 on 2019-11-28 (`tv id 13267`).


