### PR TITLE
Add: Patch Title 49 volume 8 2020 amddate #168

### DIFF
--- a/49/007-fix-2020-amddate/001.patch
+++ b/49/007-fix-2020-amddate/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/49/2020/01/2020-01-10T07:00:08-0500.xml	2020-01-14 15:49:16.000000000 -0800
++++ tmp/title_version_49_2020-01-10T07:00:08-0500_preprocessed.xml	2020-01-14 16:10:44.000000000 -0800
+@@ -282878,7 +282878,7 @@
+ 
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>Jan. 8, 2019
++<AMDDATE>Jan. 8, 2020
+ </AMDDATE>
+ 
+ <DIV1 N="8" TYPE="TITLE">

--- a/49/007-fix-2020-amddate/meta.yml
+++ b/49/007-fix-2020-amddate/meta.yml
@@ -1,0 +1,11 @@
+description: This patches Title 49 volume 8 new year 2020 amendment date that was updated to 2019 instead of 2020.
+tags: 'amendment-date'
+status: needs-approval
+issue_number: 168
+fr_doc:
+reference:
+
+patches:
+  '001':
+    start_date: '2020-01-10'
+    end_date: '2099-09-09'

--- a/49/007-fix-2020-amddate/meta.yml
+++ b/49/007-fix-2020-amddate/meta.yml
@@ -8,4 +8,4 @@ reference:
 patches:
   '001':
     start_date: '2020-01-10'
-    end_date: '2099-09-09'
+    end_date: '2020-01-30'


### PR DESCRIPTION
This patches a new year amendment date that wasn't updated for 2020. 

~This still needs to be fixed by OFR.~

This closes #168 