### PR TITLE
Patch 2020 Title 18 vol 1 reverse ammdate #167

### DIFF
--- a/18/002-fix-2020-amddate-vol1/001.patch
+++ b/18/002-fix-2020-amddate-vol1/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/18/2020/01/2020-01-11T03:00:09-0500.xml	2020-01-14 16:24:09.000000000 -0800
++++ tmp/title_version_18_2020-01-11T03:00:09-0500_preprocessed.xml	2020-01-14 16:47:18.000000000 -0800
+@@ -34,7 +34,7 @@
+ <TEXT>
+ <BODY>
+ <ECFRBRWS>
+-<AMDDATE>Jan. 9, 2019
++<AMDDATE>Jan. 9, 2020
+ </AMDDATE>
+
+ <DIV1 N="1" TYPE="TITLE">

--- a/18/002-fix-2020-amddate-vol1/meta.yml
+++ b/18/002-fix-2020-amddate-vol1/meta.yml
@@ -3,7 +3,7 @@ tags: 'amendment-date'
 status: needs-approval
 issue_number: 167
 fr_doc:
-reference:
+reference: https://criticaljuncture.basecamphq.com/projects/4648449-federal-register-2-0/posts/109798530/
 
 patches:
   '001':

--- a/18/002-fix-2020-amddate-vol1/meta.yml
+++ b/18/002-fix-2020-amddate-vol1/meta.yml
@@ -8,4 +8,4 @@ reference: https://criticaljuncture.basecamphq.com/projects/4648449-federal-regi
 patches:
   '001':
     start_date: '2020-01-11'
-    end_date: '2099-09-09'
+    end_date: '2020-01-11'

--- a/18/002-fix-2020-amddate-vol1/meta.yml
+++ b/18/002-fix-2020-amddate-vol1/meta.yml
@@ -1,0 +1,11 @@
+description: Amendment date was incremented but year was left as 2019, should be 2020.
+tags: 'amendment-date'
+status: needs-approval
+issue_number: 167
+fr_doc:
+reference:
+
+patches:
+  '001':
+    start_date: '2020-01-11'
+    end_date: '2099-09-09'


### PR DESCRIPTION
This patches a reverse amendment date in title 18, volume 1 that went in reverse. It should be year 2020.
This is present in latest and still requires an OFR fix.

This closes #167 