### PR TITLE
Close out stale amendment date patches Title 24, Title 9, Title 39

### DIFF
--- a/09/002-fix-vol2-bad-amendment-date/meta.yml
+++ b/09/002-fix-vol2-bad-amendment-date/meta.yml
@@ -8,4 +8,4 @@ reference: https://criticaljuncture.basecamphq.com/projects/4648449-federal-regi
 patches:
   '001':
     start_date: '2019-12-06'
-    end_date: '2100-01-01'
+    end_date: '2019-12-06'

--- a/24/003-patch-amddate-2018/meta.yml
+++ b/24/003-patch-amddate-2018/meta.yml
@@ -8,6 +8,4 @@ reference:
 patches:
   '001':
     start_date: '2018-07-06'
-    # end_date: '2018-07-24'
-    end_date: '2099-07-24'
-
+    end_date: '2018-07-24'

--- a/39/001-missing-id/meta.yml
+++ b/39/001-missing-id/meta.yml
@@ -8,4 +8,4 @@ patches:
     end_date: '2018-09-26'
   '002':
     start_date: '2019-09-13'
-    end_date: '2099-09-09'
+    end_date: '2019-11-23'


### PR DESCRIPTION
This closes out patches for Title 24, Title 9 that are no longer active. 
This closes #184 
This closes #189 