### PR TITLE
Add: Patch to remove Title 41 duplicate reserved subchapter H-Z #251

### DIFF
--- a/41/006-remove-duplicate-reserved-subchapter-H-Z/001.patch
+++ b/41/006-remove-duplicate-reserved-subchapter-H-Z/001.patch
@@ -1,0 +1,17 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/41/2017/01/2017-01-03.xml	2020-07-14 12:29:58.000000000 -0700
++++ tmp/title_version_41_2017-01-03T00:00:00-0500_preprocessed.xml	2020-07-14 13:06:43.000000000 -0700
+@@ -20001,14 +20001,6 @@
+
+ <HEAD> CHAPTER 102 - FEDERAL MANAGEMENT REGULATION</HEAD>
+
+-<DIV4 N="H-Z" TYPE="SUBCHAP">
+-<HEAD>SUBCHAPTERS H-Z [RESERVED]
+-
+-
+-</HEAD>
+-</DIV4>
+-
+-
+ <DIV4 N="A" TYPE="SUBCHAP">
+ <HEAD>SUBCHAPTER A - GENERAL
+

--- a/41/006-remove-duplicate-reserved-subchapter-H-Z/meta.yml
+++ b/41/006-remove-duplicate-reserved-subchapter-H-Z/meta.yml
@@ -1,0 +1,13 @@
+description: This removes a duplicate reserved Subchapter H-Z. This node is also affected by earlier patch to fix missing identifier.
+tags: transcription-error
+status: needs-review
+issue_number: 251
+fr_doc: 
+reference: 
+  pdf: https://www.govinfo.gov/content/pkg/CFR-2019-title41-vol3/pdf/CFR-2019-title41-vol3-subtitleC-chap102-subchapH-id2162.pdf
+  govinfo: https://www.govinfo.gov/app/collection/cfr/2019/title41/subtitleC/chapter102
+
+patches:
+  '001':
+    start_date: '2017-01-03'
+    end_date:   '2100-01-01'


### PR DESCRIPTION
This removes a duplicate reserved Subchapter H-Z that is placed at the beginning of the chapter instead of at the end. This closes #251 