### PR TITLE
Patch 2020 title 24 vol 2 2020 amddate

### DIFF
--- a/24/004-patch-2020-reverse-amddate/meta.yml
+++ b/24/004-patch-2020-reverse-amddate/meta.yml
@@ -8,4 +8,4 @@ reference:
 patches:
   '001':
     start_date: '2020-06-29'
-    end_date: '2100-01-01'
+    end_date: '2020-06-29'

--- a/24/005-patch-2020-vol-2-reverse-amddate/001.patch
+++ b/24/005-patch-2020-vol-2-reverse-amddate/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/24/2020/07/2020-07-28T22:00:12-0400.xml	2020-07-30 09:42:26.000000000 -0700
++++ tmp/title_version_24_2020-07-28T22:00:12-0400_preprocessed.xml	2020-07-30 09:42:50.000000000 -0700
+@@ -34224,7 +34224,7 @@
+ 
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>July 27, 2019
++<AMDDATE>July 27, 2020
+ </AMDDATE>
+ 
+ <DIV1 N="2" TYPE="TITLE">

--- a/24/005-patch-2020-vol-2-reverse-amddate/meta.yml
+++ b/24/005-patch-2020-vol-2-reverse-amddate/meta.yml
@@ -1,0 +1,11 @@
+description: 'Patch Title 24 volume 2 amddate to be 2020 instead of 2019.'
+tags: 'amendment-date'
+status: 'needs-approval'
+issue_number: 257
+fr_doc: https://www.federalregister.gov/documents/2020/06/26/2020-13090/federal-housing-administration-fha-section-232-healthcare-facility-insurance-program-updating
+reference:
+
+patches:
+  '001':
+    start_date: '2020-07-28'
+    end_date: '2100-01-01'


### PR DESCRIPTION
This closes out a previous patch for title 24 vol 2 and adds a  new patch to fix a reverse amddate for the same title and volume.

This closes #257 