### PR TITLE
Add: Patch malformed Title 40 Vol 26 amddate #273

### DIFF
--- a/40/021-2020-malformed-amddate-vol-26/001.patch
+++ b/40/021-2020-malformed-amddate-vol-26/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/40/2020/08/2020-08-13_98cf6944.xml	2020-08-14 11:26:36.000000000 -0700
++++ tmp/title_version_40_2020-08-13T20:30:42-0400_preprocessed.xml	2020-08-14 11:30:14.000000000 -0700
+@@ -849632,7 +849632,7 @@
+ 
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>Aug 12180.350, 2020
++<AMDDATE>Aug 12, 2020
+ </AMDDATE>
+ 
+ <DIV1 N="26" TYPE="TITLE">

--- a/40/021-2020-malformed-amddate-vol-26/meta.yml
+++ b/40/021-2020-malformed-amddate-vol-26/meta.yml
@@ -1,0 +1,11 @@
+description: 'Patch malformed amendment date, section accidentally inserted inside date'
+tags: amendment-date
+status: needs-review
+issue_number: 273
+fr_doc: 
+reference: 
+
+patches:
+  '001':
+    start_date: '2020-08-13'
+    end_date:   '2100-01-01'


### PR DESCRIPTION
Fixes malformed amendment date, appears to have section `180.350` accidentally pasted into middle of date. 
August 12 matches other volume changes. 

```diff
-<AMDDATE>Aug 12180.350, 2020
+<AMDDATE>Aug 12, 2020
```

This closes #273 

