### PR TITLE
Patch title 29 subpart issues

### DIFF
--- a/29/007-title-29-incorrect-part-96-subpart-c-id/001.patch
+++ b/29/007-title-29-incorrect-part-96-subpart-c-id/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/29/2017/01/2017-01-03_58f48a6a.xml	2020-08-17 11:37:16.000000000 -0700
++++ tmp/title_version_29_2017-01-03T00:00:00-0500_preprocessed.xml	2020-08-17 11:38:08.000000000 -0700
+@@ -30139,7 +30139,7 @@
+ </DIV6>
+
+
+-<DIV6 N="A" TYPE="SUBPART">
++<DIV6 N="C" TYPE="SUBPART">
+ <HEAD>Subpart C - Audits of Entities Not Covered by Subpart A</HEAD>
+
+

--- a/29/007-title-29-incorrect-part-96-subpart-c-id/meta.yml
+++ b/29/007-title-29-incorrect-part-96-subpart-c-id/meta.yml
@@ -1,0 +1,11 @@
+description: 'This patches incorrect identifier of Part 96 Subpart C'
+tags: 'transcription-error'
+status:  'needs-approval'
+issue_number: 275
+fr_doc: 
+reference:
+
+patches:
+  '001':
+    start_date: '2017-01-03'
+    end_date: '2100-01-01'

--- a/29/008-title-29-incorrect-part-417-subpart-B/001.patch
+++ b/29/008-title-29-incorrect-part-417-subpart-B/001.patch
@@ -1,0 +1,10 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/29/2017/01/2017-01-03_58f48a6a.xml	2020-08-17 11:56:21.000000000 -0700
++++ tmp/title_version_29_2017-01-03T00:00:00-0500_preprocessed.xml	2020-08-17 12:11:13.000000000 -0700
+@@ -39230,7 +39230,7 @@
+ </DIV6>
+
+
+-<DIV6 N="A" TYPE="SUBPART">
++<DIV6 N="B" TYPE="SUBPART">
+ <HEAD>Subpart B - Procedures Upon Failure of Union To Take Appropriate Remedial Action Following Subpart A Procedures</HEAD>
+

--- a/29/008-title-29-incorrect-part-417-subpart-B/meta.yml
+++ b/29/008-title-29-incorrect-part-417-subpart-B/meta.yml
@@ -1,7 +1,7 @@
 description: 'This patches incorrect identifier of Part 417 Subpart B'
 tags: 'transcription-error'
 status:  'needs-approval'
-issue_number: 275
+issue_number: 276
 fr_doc: 
 reference:
 

--- a/29/008-title-29-incorrect-part-417-subpart-B/meta.yml
+++ b/29/008-title-29-incorrect-part-417-subpart-B/meta.yml
@@ -1,0 +1,11 @@
+description: 'This patches incorrect identifier of Part 417 Subpart B'
+tags: 'transcription-error'
+status:  'needs-approval'
+issue_number: 275
+fr_doc: 
+reference:
+
+patches:
+  '001':
+    start_date: '2017-01-03'
+    end_date: '2100-01-01'

--- a/29/009-title-29-incorrect-part-2590-subpart-D/001.patch
+++ b/29/009-title-29-incorrect-part-2590-subpart-D/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/29/2017/01/2017-01-03_58f48a6a.xml	2020-08-17 14:48:06.000000000 -0700
++++ tmp/title_version_29_2017-01-03T00:00:00-0500_preprocessed.xml	2020-08-17 14:54:22.000000000 -0700
+@@ -252199,7 +252199,7 @@
+ </DIV6>
+
+
+-<DIV6 N="B" TYPE="SUBPART">
++<DIV6 N="D" TYPE="SUBPART">
+ <HEAD>Subpart D - General Provisions Related to Subparts B and C</HEAD>
+
+ <SOURCE>

--- a/29/009-title-29-incorrect-part-2590-subpart-D/meta.yml
+++ b/29/009-title-29-incorrect-part-2590-subpart-D/meta.yml
@@ -1,0 +1,11 @@
+description: 'This patches incorrect identifier of Part 2590 Subpart D'
+tags: 'transcription-error'
+status:  'needs-approval'
+issue_number: 277
+fr_doc: 
+reference:
+
+patches:
+  '001':
+    start_date: '2017-01-03'
+    end_date: '2100-01-01'


### PR DESCRIPTION
This fixes 3 subparts in Title 29 that have an incorrect identifier assigned.

This closes #275 
This closes #276
This closes #277