### PR TITLE
Patch suspended subparts in Title 49 Part 365

### DIFF
--- a/49/009-change-part-365-suspended-subpart-d-id/001.patch
+++ b/49/009-change-part-365-suspended-subpart-d-id/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/49/2017/01/2017-01-24_6922a004.xml	2020-08-31 11:16:44.000000000 -0700
++++ tmp/title_version_49_2017-01-24T00:00:00-0500_preprocessed.xml	2020-08-31 11:17:18.000000000 -0700
+@@ -175454,7 +175454,7 @@
+ </DIV6>
+
+
+-<DIV6 N="D" TYPE="SUBPART">
++<DIV6 N="D-suspended" TYPE="SUBPART">
+ <HEAD>Subpart D - Transfers of Operating Authority</HEAD>
+
+ <SOURCE>

--- a/49/009-change-part-365-suspended-subpart-d-id/meta.yml
+++ b/49/009-change-part-365-suspended-subpart-d-id/meta.yml
@@ -1,0 +1,11 @@
+description: 'Add trailing -suspended to subpart that should be marked as suspended'
+tags: 'transcription-error'
+status: 'approved'
+issue_number: 281
+fr_doc:
+reference:
+
+patches:
+  '001':
+    start_date: '2017-01-24'
+    end_date:   '2100-01-01'

--- a/49/010-change-part-365-suspended-subpart-e-id/001.patch
+++ b/49/010-change-part-365-suspended-subpart-e-id/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/49/2017/01/2017-01-24_6922a004.xml     	2020-08-31 11:39:36.000000000 -0700
++++ tmp/title_version_49_2017-01-24T00:00:00-0500_preprocessed.xml	2020-08-31 11:48:36.000000000 -0700
+@@ -195837,7 +195837,7 @@
+ </DIV6>
+
+
+-<DIV6 N="E" TYPE="SUBPART">
++<DIV6 N="E-suspended" TYPE="SUBPART">
+ <HEAD>Subpart E - URS Online Application</HEAD>
+
+

--- a/49/010-change-part-365-suspended-subpart-e-id/meta.yml
+++ b/49/010-change-part-365-suspended-subpart-e-id/meta.yml
@@ -1,0 +1,11 @@
+description: 'Add trailing -suspended to subpart that should be marked as suspended'
+tags: 'transcription-error'
+status: 'approved'
+issue_number: 282
+fr_doc:
+reference:
+
+patches:
+  '001':
+    start_date: '2017-01-24'
+    end_date:   '2100-01-01'


### PR DESCRIPTION
This corrects two issues in Title 49 relating to suspended subparts. These should have been removed but instead are going to be marked as suspended since they're still in the present XML and should have been handled in 2017. 

This closes #281 
This closes #282