### PR TITLE
Add: Patch Title 38 Part 21 reserved subpart range colliding with active subpart

### DIFF
--- a/38/002-fix-subpart-part-21-subparts-F1-F3-id/001.patch
+++ b/38/002-fix-subpart-part-21-subparts-F1-F3-id/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/38/2017/01/2017-01-03_7bec5460.xml	2020-09-01 10:07:12.000000000 -0700
++++ tmp/title_version_38_2017-01-03T00:00:00-0500_preprocessed.xml	2020-09-01 10:07:51.000000000 -0700
+@@ -57528,7 +57528,7 @@
+ </DIV6>
+
+
+-<DIV6 N="F" TYPE="SUBPART">
++<DIV6 N="F-1 - F-3" TYPE="SUBPART">
+ <HEAD>Subparts F-1 - F-3 [Reserved]</HEAD>
+
+ </DIV6>

--- a/38/002-fix-subpart-part-21-subparts-F1-F3-id/meta.yml
+++ b/38/002-fix-subpart-part-21-subparts-F1-F3-id/meta.yml
@@ -1,0 +1,11 @@
+description: Fix reserved range identifier that is colliding with active Subpart F.
+tags: 'transcription-error'
+status: 'needs-review'
+issue_number: 289
+fr_doc:
+reference:
+
+patches:
+  '001':
+    start_date: '2017-01-03'
+    end_date: '2100-01-01'


### PR DESCRIPTION
This fixes a reserved subpart range that is causing an active subpart with the same id to 404. This closes #289 