### PR TITLE
Add: Patch incorrect reserved range identifier in Title 12 Part 1223 subpart C-Z

### DIFF
--- a/12/011-fix-colliding-title-12-part-1223-reserved-subpart/001.patch
+++ b/12/011-fix-colliding-title-12-part-1223-reserved-subpart/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/12/2017/03/2017-03-28_2a3aa1bf.xml	2020-09-01 11:41:35.000000000 -0700
++++ tmp/title_version_12_2017-03-28T01:00:00-0400_preprocessed.xml	2020-09-01 11:46:06.000000000 -0700
+@@ -319992,7 +319992,7 @@
+ </DIV6>
+
+
+-<DIV6 N="C" TYPE="SUBPART">
++<DIV6 N="C-Z" TYPE="SUBPART">
+ <HEAD>Subparts C-Z [Reserved]</HEAD>
+
+ </DIV6>

--- a/12/011-fix-colliding-title-12-part-1223-reserved-subpart/meta.yml
+++ b/12/011-fix-colliding-title-12-part-1223-reserved-subpart/meta.yml
@@ -1,0 +1,11 @@
+description: 'Patch incorrect reserved range identifier in Title 12 Part 1223 that is colliding with active Subpart C.'
+tags: 'transcription-error'
+status: 'needs-approval'
+fr_doc:
+issue: 285
+reference:
+
+patches:
+  '001':
+    start_date: '2017-03-28' #520
+    end_date: '2100-01-01'

--- a/12/011-fix-colliding-title-12-part-1223-reserved-subpart/meta.yml
+++ b/12/011-fix-colliding-title-12-part-1223-reserved-subpart/meta.yml
@@ -7,5 +7,5 @@ reference:
 
 patches:
   '001':
-    start_date: '2017-03-28' #520
+    start_date: '2017-03-28'
     end_date: '2100-01-01'


### PR DESCRIPTION
This fixes a ranged identifier to prevent a collision with active Subpart C in Part 1223. 

Issue #285