### PR TITLE
Patch title 26 vol 8 2020 amddate

### DIFF
--- a/26/003-patch-title-26-amddates-2020/meta.yml
+++ b/26/003-patch-title-26-amddates-2020/meta.yml
@@ -8,4 +8,4 @@ reference:
 patches:
   '001':
     start_date: '2020-03-10'
-    end_date: '2100-01-01'
+    end_date: '2020-09-08'

--- a/26/006-vol-8-2019-reverse-amddate/001.patch
+++ b/26/006-vol-8-2019-reverse-amddate/001.patch
@@ -1,0 +1,11 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/26/2020/09/2020-09-09_06c88d8c.xml	2020-09-10 09:43:19.000000000 -0700
++++ tmp/title_version_26_2020-09-09T16:20:22-0400_preprocessed.xml	2020-09-10 09:48:01.000000000 -0700
+@@ -137387,7 +137387,7 @@
+
+ </ECFRBRWS>
+ <ECFRBRWS>
+-<AMDDATE>Sept. 4, 2019
++<AMDDATE>Sept. 4, 2020
+ </AMDDATE>
+
+ <DIV1 N="8" TYPE="TITLE">

--- a/26/006-vol-8-2019-reverse-amddate/meta.yml
+++ b/26/006-vol-8-2019-reverse-amddate/meta.yml
@@ -1,0 +1,11 @@
+description: Patch Title 26 volumes 8 2020 reverse amddate
+tags: amendment-date
+status: needs-approval
+issue_number: 230
+fr_doc: https://www.federalregister.gov/documents/2020/09/04/2020-16955/nuclear-decommissioning-funds
+reference:
+
+patches:
+  '001':
+    start_date: '2020-09-09'
+    end_date: '2100-01-01'


### PR DESCRIPTION
This closes out a no longer applicable amendment date and creates a new patch to fix a reverse amendment date initialized in yesterdays title 26 title version.

issue #230 