### PR TITLE
Add: Patch incorrectly inserted Subpart B as F #308

### DIFF
--- a/02/02-fix-part-1401-incorrect-subpart-b/001.patch
+++ b/02/02-fix-part-1401-incorrect-subpart-b/001.patch
@@ -1,0 +1,13 @@
+--- /Users/Andrew/code/ecfr-versioner/data/titles/preprocessed/xml/02/2017/01/2017-01-03_25104cb7.xml	2020-09-10 11:17:39.000000000 -0700
++++ tmp/title_version_2_2017-01-03T00:00:00-0500_preprocessed.xml	2020-09-10 11:46:06.000000000 -0700
+@@ -19213,8 +19213,8 @@
+ </DIV6>
+
+
+-<DIV6 N="F" TYPE="SUBPART">
+-<HEAD>Subpart F - Definitions</HEAD>
++<DIV6 N="B" TYPE="SUBPART">
++<HEAD>Subpart B - Definitions</HEAD>
+
+
+ <DIV8 N="§ 1401.205" TYPE="SECTION">

--- a/02/02-fix-part-1401-incorrect-subpart-b/meta.yml
+++ b/02/02-fix-part-1401-incorrect-subpart-b/meta.yml
@@ -1,0 +1,11 @@
+description: 'Part 1401 subpart B was inserted as subpart F. Correct head tag and identifier'
+tags: 'transcription-error'
+status: 'needs-approval'
+fr_doc: https://www.federalregister.gov/documents/2010/11/22/2010-29371/department-of-the-interior-implementation-of-omb-guidance-on-drug-free-workplace-requirements
+issue: 308
+reference:
+
+patches:
+  '001':
+    start_date: '2017-01-03'
+    end_date: '2019-07-09'


### PR DESCRIPTION
Fixes issue where Subpart B was inserted as Subpart F leading to duplicate Subpart Fs and Subpart B having incorrect headings.

Fixed in latest source xml. 

this closes #308 